### PR TITLE
Fixes prod deploy by adding matrix to test command

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,7 +31,9 @@ jobs:
           NETWORK: ${{ matrix.network }}
         run: yarn codegen:$NETWORK
       - name: Test
-        run: yarn test
+        env:
+          NETWORK: ${{ matrix.network }}
+        run: yarn test:$NETWORK
       - name: Build
         env:
           NETWORK: ${{ matrix.network }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "prepare:arbitrum-testnet": "yarn workspaces run prepare:arbitrum-testnet",
     "prepare:arbitrum": "yarn workspaces run prepare:arbitrum",
     "prepare:mainnet": "yarn workspaces run prepare:mainnet",
-    "test": "yarn workspaces run test"
+    "test:arbitrum-testnet": "yarn workspaces run test:arbitrum-testnet",
+    "test:arbitrum": "yarn workspaces run test:arbitrum",
+    "test:mainnet": "yarn workspaces run test:mainnet"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.26.0",

--- a/packages/abis/package.json
+++ b/packages/abis/package.json
@@ -20,6 +20,8 @@
     "prepare:arbitrum-testnet": "true",
     "prepare:arbitrum": "true",
     "prepare:mainnet": "true",
-    "test": "true"
+    "test:arbitrum-testnet": "true",
+    "test:arbitrum": "true",
+    "test:mainnet": "true"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,6 +20,8 @@
     "prepare:arbitrum-testnet": "true",
     "prepare:arbitrum": "true",
     "prepare:mainnet": "true",
-    "test": "true"
+    "test:arbitrum-testnet": "true",
+    "test:arbitrum": "true",
+    "test:mainnet": "true"
   }
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -18,6 +18,8 @@
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json src/index.template.ts > index.ts",
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json src/index.template.ts > index.ts",
     "prepare:mainnet": "mustache ../../node_modules/@treasure/subgraph-config/src/mainnet.json src/index.template.ts > index.ts",
-    "test": "true"
+    "test:arbitrum-testnet": "true",
+    "test:arbitrum": "true",
+    "test:mainnet": "true"
   }
 }

--- a/subgraphs/bridgeworld-stats/package.json
+++ b/subgraphs/bridgeworld-stats/package.json
@@ -16,6 +16,8 @@
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "graph test -- --lib=../../node_modules/"
+    "test:arbitrum-testnet": "graph test -- --lib=../../node_modules/",
+    "test:arbitrum": "graph test -- --lib=../../node_modules/",
+    "test:mainnet": "true"
   }
 }

--- a/subgraphs/bridgeworld/package.json
+++ b/subgraphs/bridgeworld/package.json
@@ -16,6 +16,8 @@
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "graph test -- --lib=../../node_modules/"
+    "test:arbitrum-testnet": "graph test -- --lib=../../node_modules/",
+    "test:arbitrum": "graph test -- --lib=../../node_modules/",
+    "test:mainnet": "true"
   }
 }

--- a/subgraphs/marketplace/package.json
+++ b/subgraphs/marketplace/package.json
@@ -16,6 +16,8 @@
     "prepare:arbitrum-testnet": "true",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "true"
+    "test:arbitrum-testnet": "true",
+    "test:arbitrum": "true",
+    "test:mainnet": "true"
   }
 }

--- a/subgraphs/migration/package.json
+++ b/subgraphs/migration/package.json
@@ -16,6 +16,8 @@
     "prepare:arbitrum-testnet": "true",
     "prepare:arbitrum": "true",
     "prepare:mainnet": "mustache ../../node_modules/@treasure/subgraph-config/src/mainnet.json template.yaml > subgraph.yaml",
-    "test": "true"
+    "test:arbitrum-testnet": "true",
+    "test:arbitrum": "true",
+    "test:mainnet": "true"
   }
 }

--- a/subgraphs/snapshot/package.json
+++ b/subgraphs/snapshot/package.json
@@ -16,6 +16,8 @@
     "prepare:arbitrum-testnet": "true",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "true"
+    "test:arbitrum-testnet": "true",
+    "test:arbitrum": "true",
+    "test:mainnet": "true"
   }
 }


### PR DESCRIPTION
Fixes production deploy ([see failed job here](https://github.com/TreasureProject/treasure-subgraphs/runs/5058785118?check_suite_focus=true)) by adding the matrix of networks to the test command, as test are reliant on network-specific data like `subgraphy.yaml` and the generated classes.