### PR TITLE
Fix bridgeworld-stats subgraph deploy

### DIFF
--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -8,8 +8,8 @@ enum Interval {
 }
 
 interface Stat {
-  startTimestamp: BigInt!
-  endTimestamp: BigInt!
+  startTimestamp: BigInt
+  endTimestamp: BigInt
 }
 
 type User @entity {


### PR DESCRIPTION
- Fixes error encountered with the bridgeworld-stats subgraph deployment: https://github.com/TreasureProject/treasure-subgraphs/runs/5171557827?check_suite_focus=true#step:10:82

For some reason this typecheck only comes up on a deploy, not a build :/