### PR TITLE
[bridgeworld-stats] add summoning stats

### DIFF
--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -60,8 +60,11 @@ type AtlasMineLockStat implements Stat @entity {
 type AtlasMineStat implements Stat @entity {
   id: ID!
 
-  "Internal for tracking unique addresses"
+  "Internal for tracking active unique addresses"
   _activeAddresses: [String!]!
+
+  "Internal for tracking all unique addresses"
+  _allAddresses: [String!]!
 
   startTimestamp: BigInt
   endTimestamp: BigInt
@@ -72,7 +75,13 @@ type AtlasMineStat implements Stat @entity {
   magicDeposited: BigInt!
   magicWithdrawn: BigInt!
   magicHarvested: BigInt!
+  
+  "Number of unique addresses actively staking throughout time period"
   activeAddressesCount: Int!
+
+  "Number of unique addresses that have staked at any point"
+  allAddressesCount: Int!
+
   lockStats: [AtlasMineLockStat!]! @derivedFrom(field: "atlasMineStat")
 }
 
@@ -86,8 +95,11 @@ type Pilgrimage @entity {
 type SummoningStat implements Stat @entity {
   id: ID!
 
-  "Internal for tracking unique active addresses"
+  "Internal for tracking active unique addresses"
   _activeAddresses: [String!]!
+
+  "Internal for tracking all unique addresses"
+  _allAddresses: [String!]!
 
   startTimestamp: BigInt
   endTimestamp: BigInt
@@ -104,6 +116,9 @@ type SummoningStat implements Stat @entity {
 
   "Number of unique addresses actively summoning throughout time period"
   activeAddressesCount: Int!
+
+  "Number of unique addresses that have summoned at any point"
+  allAddressesCount: Int!
 
   legionStats: [SummoningLegionStat!]! @derivedFrom(field: "summoningStat")
 }

--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -7,6 +7,21 @@ enum Interval {
   AllTime
 }
 
+enum LegionGeneration {
+  Genesis
+  Auxiliary
+  Recruit
+}
+
+enum LegionRarity {
+  Legendary
+  Rare
+  Special
+  Uncommon
+  Common
+  None
+}
+
 interface Stat {
   startTimestamp: BigInt
   endTimestamp: BigInt
@@ -22,6 +37,14 @@ type User @entity {
   magicHarvested: BigInt!
   summonsStarted: Int!
   summonsFinished: Int!
+}
+
+type Legion @entity {
+  id: ID!
+  tokenId: BigInt!
+  generation: LegionGeneration!
+  rarity: LegionRarity!
+  name: String!
 }
 
 type AtlasMineLockStat implements Stat @entity {
@@ -72,4 +95,24 @@ type SummoningStat implements Stat @entity {
   summonsStarted: Int!
   summonsFinished: Int!
   activeAddressesCount: Int!
+  legionStats: [SummoningLegionStat!]! @derivedFrom(field: "summoningStat")
+}
+
+type SummoningLegionStat implements Stat @entity {
+  id: ID!
+  startTimestamp: BigInt
+  endTimestamp: BigInt
+  summoningStat: SummoningStat!
+  generation: LegionGeneration!
+  rarity: LegionRarity!
+  name: String!
+
+  "Number of Summons started by this type of Legion"
+  summonsStarted: Int!
+
+  "Number of Summons finished by this type of Legion"
+  summonsFinished: Int!
+
+  "Number of Summons that have resulted in the creation of this type of Legion"
+  summonedCount: Int!
 }

--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -20,6 +20,8 @@ type User @entity {
   magicDeposited: BigInt!
   magicWithdrawn: BigInt!
   magicHarvested: BigInt!
+  summonsStarted: Int!
+  summonsFinished: Int!
 }
 
 type AtlasMineLockStat implements Stat @entity {
@@ -56,4 +58,18 @@ type Pilgrimage @entity {
 
   current: Int!
   total: Int!
+}
+
+type SummoningStat implements Stat @entity {
+  id: ID!
+
+  "Internal for tracking unique addresses"
+  _activeAddresses: [String!]!
+
+  startTimestamp: BigInt
+  endTimestamp: BigInt
+  interval: Interval!
+  summonsStarted: Int!
+  summonsFinished: Int!
+  activeAddressesCount: Int!
 }

--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -86,15 +86,25 @@ type Pilgrimage @entity {
 type SummoningStat implements Stat @entity {
   id: ID!
 
-  "Internal for tracking unique addresses"
+  "Internal for tracking unique active addresses"
   _activeAddresses: [String!]!
 
   startTimestamp: BigInt
   endTimestamp: BigInt
   interval: Interval!
+
+  "$MAGIC spent on Summons"
+  magicSpent: BigInt!
+
+  "Number of Summons started by all Legions"
   summonsStarted: Int!
+
+  "Number of Summons finished by all Legions"
   summonsFinished: Int!
+
+  "Number of unique addresses actively summoning throughout time period"
   activeAddressesCount: Int!
+
   legionStats: [SummoningLegionStat!]! @derivedFrom(field: "summoningStat")
 }
 
@@ -107,12 +117,15 @@ type SummoningLegionStat implements Stat @entity {
   rarity: LegionRarity!
   name: String!
 
-  "Number of Summons started by this type of Legion"
+  "$MAGIC spent on Summons by this Legion type"
+  magicSpent: BigInt!
+
+  "Number of Summons started by this Legion type"
   summonsStarted: Int!
 
-  "Number of Summons finished by this type of Legion"
+  "Number of Summons finished by this Legion type"
   summonsFinished: Int!
 
-  "Number of Summons that have resulted in the creation of this type of Legion"
+  "Number of Summons that have resulted in the creation of this Legion type"
   summonedCount: Int!
 }

--- a/subgraphs/bridgeworld-stats/src/helpers/constants.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/constants.ts
@@ -1,3 +1,5 @@
+import { BigDecimal } from "@graphprotocol/graph-ts";
+
 export const LEGION_GENERATIONS = [
   "Genesis",
   "Auxiliary",
@@ -12,3 +14,5 @@ export const LEGION_RARITIES = [
   "Common",
   "None",
 ];
+
+export const ONE_WEI = BigDecimal.fromString((1e18).toString());

--- a/subgraphs/bridgeworld-stats/src/helpers/constants.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/constants.ts
@@ -1,0 +1,14 @@
+export const LEGION_GENERATIONS = [
+  "Genesis",
+  "Auxiliary",
+  "Recruit"
+];
+
+export const LEGION_RARITIES = [
+  "Legendary",
+  "Rare",
+  "Special",
+  "Uncommon",
+  "Common",
+  "None",
+];

--- a/subgraphs/bridgeworld-stats/src/helpers/ids.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/ids.ts
@@ -1,3 +1,6 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+import { LEGION_ADDRESS } from "@treasure/constants";
+
 import { SECONDS_IN_DAY } from "./date";
 import { toPaddedString } from "./number";
 
@@ -41,4 +44,11 @@ export function getYearlyId(timestamp: i64): string {
 
 export function getAllTimeId(): string {
   return "all-time";
+}
+
+export function getLegionId(tokenId: BigInt): string {
+  return [
+    LEGION_ADDRESS.toHexString(),
+    tokenId.toHexString()
+  ].join("-");
 }

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -167,13 +167,13 @@ export function getTimeIntervalAtlasMineStats(eventTimestamp: BigInt): AtlasMine
 export function createAtlasMineStat(id: string): AtlasMineStat {
   const stat = new AtlasMineStat(id);
   stat._activeAddresses = [];
+  stat._allAddresses = [];
   stat.magicDepositCount = 0;
   stat.magicWithdrawCount = 0;
   stat.magicHarvestCount = 0;
   stat.magicDeposited = BigInt.fromI32(0);
   stat.magicWithdrawn = BigInt.fromI32(0);
   stat.magicHarvested = BigInt.fromI32(0);
-  stat.activeAddressesCount = 0;
   stat.save();
   return stat;
 }
@@ -263,6 +263,7 @@ export function getTimeIntervalSummoningStats(eventTimestamp: BigInt): Summoning
 export function createSummoningStat(id: string): SummoningStat {
   const stat = new SummoningStat(id);
   stat._activeAddresses = [];
+  stat._allAddresses = [];
   stat.magicSpent = BigInt.fromI32(0);
   stat.summonsStarted = 0;
   stat.summonsFinished = 0;

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -1,6 +1,6 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 
-import { AtlasMineLockStat, AtlasMineStat, User } from "../../generated/schema";
+import { AtlasMineLockStat, AtlasMineStat, SummoningStat, User } from "../../generated/schema";
 import {
   getDaysInMonth,
   getDaysInYear,
@@ -32,6 +32,8 @@ export function getOrCreateUser(address: Address): User {
     user.magicDeposited = BigInt.fromI32(0);
     user.magicWithdrawn = BigInt.fromI32(0);
     user.magicHarvested = BigInt.fromI32(0);
+    user.summonsStarted = 0;
+    user.summonsFinished = 0;
     user.save();
   }
 
@@ -132,4 +134,80 @@ export function getOrCreateAtlasMineLockStat(atlasMineStatId: string, lock: i32)
   }
 
   return lockStat;
+}
+
+export function getTimeIntervalSummoningStats(eventTimestamp: BigInt): SummoningStat[] {
+  const timestamp = eventTimestamp.toI64() * 1000;
+  const date = new Date(timestamp);
+  const month = date.getUTCMonth();
+  const year = date.getUTCFullYear();
+
+  // Hourly
+  const hourlyId = getHourlyId(timestamp);
+  const hourlyStat = (SummoningStat.load(hourlyId) || createSummoningStat(hourlyId)) as SummoningStat;
+  const startOfHour = getStartOfHour(timestamp);
+  hourlyStat.interval = "Hourly";
+  hourlyStat.startTimestamp = BigInt.fromI64(startOfHour);
+  hourlyStat.endTimestamp = BigInt.fromI64(startOfHour + SECONDS_IN_HOUR - 1);
+  hourlyStat.save();
+
+  // Daily
+  const dailyId = getDailyId(timestamp);
+  const dailyStat = (SummoningStat.load(dailyId) || createSummoningStat(dailyId)) as SummoningStat;
+  const startOfDay = getStartOfDay(timestamp);
+  dailyStat.interval = "Daily";
+  dailyStat.startTimestamp = BigInt.fromI64(startOfDay);
+  dailyStat.endTimestamp = BigInt.fromI64(startOfDay + SECONDS_IN_DAY - 1);
+  dailyStat.save();
+
+  // Weekly
+  const weeklyId = getWeeklyId(timestamp);
+  const weeklyStat = (SummoningStat.load(weeklyId) || createSummoningStat(weeklyId)) as SummoningStat;
+  const startOfWeek = getStartOfWeek(timestamp);
+  weeklyStat.interval = "Weekly";
+  weeklyStat.startTimestamp = BigInt.fromI64(startOfWeek);
+  weeklyStat.endTimestamp = BigInt.fromI64(startOfWeek + (SECONDS_IN_DAY * 7) - 1);
+  weeklyStat.save();
+
+  // Monthly
+  const monthlyId = getMonthlyId(timestamp);
+  const monthlyStat = (SummoningStat.load(monthlyId) || createSummoningStat(monthlyId)) as SummoningStat;
+  const startOfMonth = getStartOfMonth(timestamp);
+  monthlyStat.interval = "Monthly";
+  monthlyStat.startTimestamp = BigInt.fromI64(startOfMonth);
+  monthlyStat.endTimestamp = BigInt.fromI64(startOfMonth + (SECONDS_IN_DAY * getDaysInMonth(month, year)) - 1);
+  monthlyStat.save();
+
+  // Yearly
+  const yearlyId = getYearlyId(timestamp);
+  const yearlyStat = (SummoningStat.load(yearlyId) || createSummoningStat(yearlyId)) as SummoningStat;
+  const startOfYear = getStartOfYear(timestamp);
+  yearlyStat.interval = "Yearly";
+  yearlyStat.startTimestamp = BigInt.fromI64(startOfYear);
+  yearlyStat.endTimestamp = BigInt.fromI64(startOfYear + (SECONDS_IN_DAY * getDaysInYear(year)) - 1);
+  yearlyStat.save();
+
+  // All-time
+  const allTimeId = getAllTimeId();
+  const allTimeStat = (SummoningStat.load(allTimeId) || createSummoningStat(allTimeId)) as SummoningStat;
+  allTimeStat.interval = "AllTime";
+  allTimeStat.save();
+
+  return [
+    hourlyStat,
+    dailyStat,
+    weeklyStat,
+    monthlyStat,
+    yearlyStat,
+    allTimeStat
+  ];
+}
+
+export function createSummoningStat(id: string): SummoningStat {
+  const stat = new SummoningStat(id);
+  stat._activeAddresses = [];
+  stat.summonsStarted = 0;
+  stat.summonsFinished = 0;
+  stat.save();
+  return stat;
 }

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -22,6 +22,7 @@ import {
   getWeeklyId,
   getYearlyId
 } from "./ids";
+import { etherToWei } from "./number";
 
 export function getOrCreateUser(address: Address): User {
   const id = address.toHexString();
@@ -82,6 +83,18 @@ export function getLegionName(tokenId: BigInt, generation: i32, rarity: i32): st
   }
 
   return `${LEGION_GENERATIONS[generation]} ${LEGION_RARITIES[rarity]}`;
+}
+
+export function getLegionSummonCost(generation: string): BigInt {
+  if (generation == "Auxiliary") {
+    return etherToWei(500);
+  }
+
+  if (generation == "Genesis") {
+    return etherToWei(300);
+  }
+
+  return BigInt.fromI32(0);
 }
 
 export function getTimeIntervalAtlasMineStats(eventTimestamp: BigInt): AtlasMineStat[] {
@@ -250,18 +263,14 @@ export function getTimeIntervalSummoningStats(eventTimestamp: BigInt): Summoning
 export function createSummoningStat(id: string): SummoningStat {
   const stat = new SummoningStat(id);
   stat._activeAddresses = [];
+  stat.magicSpent = BigInt.fromI32(0);
   stat.summonsStarted = 0;
   stat.summonsFinished = 0;
   stat.save();
   return stat;
 }
 
-export function getOrCreateSummoningLegionStat(summoningStatId: string, tokenId: BigInt): SummoningLegionStat | null {
-  const legion = getLegion(tokenId);
-  if (!legion) {
-    return null;
-  }
-
+export function getOrCreateSummoningLegionStat(summoningStatId: string, legion: Legion): SummoningLegionStat {
   const id = `${summoningStatId}-${legion.name.toLowerCase().split(" ").join("-")}`;
   let stat = SummoningLegionStat.load(id);
   if (!stat) {
@@ -270,6 +279,7 @@ export function getOrCreateSummoningLegionStat(summoningStatId: string, tokenId:
     stat.generation = legion.generation;
     stat.rarity = legion.rarity;
     stat.name = legion.name;
+    stat.magicSpent = BigInt.fromI32(0);
     stat.summonsStarted = 0;
     stat.summonsFinished = 0;
     stat.summonedCount = 0;

--- a/subgraphs/bridgeworld-stats/src/helpers/number.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/number.ts
@@ -1,7 +1,16 @@
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+import { ONE_WEI } from "./constants";
+
 export function toPaddedString(number: i32): string {
   if (number < 10) {
     return `0${number}`;
   }
 
   return number.toString();
+}
+
+export function etherToWei(ether: i32): BigInt {
+  return BigInt.fromString(
+    BigDecimal.fromString(ether.toString()).times(ONE_WEI).toString()
+  );
 }

--- a/subgraphs/bridgeworld-stats/src/mappings/atlas-mine.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/atlas-mine.ts
@@ -26,6 +26,12 @@ export function handleDeposit(event: Deposit): void {
       stat._activeAddresses = stat._activeAddresses.concat([user.id]);
       stat.activeAddressesCount = stat._activeAddresses.length;
     }
+
+    if (!stat._allAddresses.includes(user.id)) {
+      stat._allAddresses = stat._allAddresses.concat([user.id]);
+      stat.allAddressesCount = stat._allAddresses.length;
+    }
+    
     stat.save();
 
     const lockStat = getOrCreateAtlasMineLockStat(stat.id, params.lock);

--- a/subgraphs/bridgeworld-stats/src/mappings/legion.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/legion.ts
@@ -1,0 +1,16 @@
+import { LegionCreated } from "../../generated/Legion Metadata Store/LegionMetadataStore";
+import { LEGION_GENERATIONS, LEGION_RARITIES } from "../helpers/constants";
+import { getLegionName, getOrCreateLegion } from "../helpers/models";
+
+export function handleLegionCreated(event: LegionCreated): void {
+  const params = event.params;
+
+  const tokenId = params._tokenId;
+  const generation = params._generation;
+  const rarity = params._rarity;
+  const legion = getOrCreateLegion(tokenId);
+  legion.generation = LEGION_GENERATIONS[generation];
+  legion.rarity = LEGION_RARITIES[rarity];
+  legion.name = getLegionName(tokenId, generation, rarity);
+  legion.save();
+}

--- a/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
@@ -33,6 +33,11 @@ export function handleSummoningStarted(event: SummoningStarted): void {
       stat.activeAddressesCount = stat._activeAddresses.length;
     }
 
+    if (!stat._allAddresses.includes(user.id)) {
+      stat._allAddresses = stat._allAddresses.concat([user.id]);
+      stat.allAddressesCount = stat._allAddresses.length;
+    }
+
     if (legion) {
       const summonCost = getLegionSummonCost(legion.generation);
       stat.magicSpent = stat.magicSpent.plus(summonCost);

--- a/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
@@ -1,0 +1,50 @@
+import {
+  SummoningFinished,
+  SummoningStarted,
+} from "../../generated/Summoning/Summoning";
+import { getOrCreateUser, getTimeIntervalSummoningStats } from "../helpers/models";
+
+export function handleSummoningStarted(event: SummoningStarted): void {
+  
+  const params = event.params;
+
+  const user = getOrCreateUser(params._user);
+  user.summonsStarted += 1;
+  user.save();
+
+  const stats = getTimeIntervalSummoningStats(event.block.timestamp);
+  for (let i = 0; i < stats.length; i++) {
+    const stat = stats[i];
+    stat.summonsStarted += 1;
+    if (!stat._activeAddresses.includes(user.id)) {
+      stat._activeAddresses = stat._activeAddresses.concat([user.id]);
+      stat.activeAddressesCount = stat._activeAddresses.length;
+    }
+    stat.save();
+  }
+}
+
+export function handleSummoningFinished(event: SummoningFinished): void {
+  const params = event.params;
+
+  const user = getOrCreateUser(params._user);
+  user.summonsFinished += 1;
+  user.save();
+  const isUserSummoning = user.summonsStarted > user.summonsFinished;
+
+  const stats = getTimeIntervalSummoningStats(event.block.timestamp);
+  for (let i = 0; i < stats.length; i++) {
+    const stat = stats[i];
+    stat.summonsFinished += 1;
+    if (!isUserSummoning) {
+      const addressIndex = stat._activeAddresses.indexOf(user.id);
+      if (addressIndex >= 0) {
+        const addresses = stat._activeAddresses;
+        addresses.splice(addressIndex, 1);
+        stat._activeAddresses = addresses;
+        stat.activeAddressesCount = addresses.length;
+      }
+    }
+    stat.save();
+  }
+}

--- a/subgraphs/bridgeworld-stats/template.yaml
+++ b/subgraphs/bridgeworld-stats/template.yaml
@@ -28,6 +28,26 @@ dataSources:
         - event: Harvest(indexed address,indexed uint256,uint256)
           handler: handleHarvest
       file: ./src/mappings/atlas-mine.ts
+  - name: Legion Metadata Store
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      address: "{{ legion_metadata_store_address }}"
+      abi: LegionMetadataStore
+      startBlock: {{ legion_metadata_store_start_block }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Legion
+      abis:
+        - name: LegionMetadataStore
+          file: ../../node_modules/@treasure/subgraph-abis/src/LegionMetadataStore.json
+      eventHandlers:
+        - event: LegionCreated(indexed address,indexed uint256,uint8,uint8,uint8)
+          handler: handleLegionCreated
+      file: ./src/mappings/legion.ts
   - name: Pilgrimage
     kind: ethereum/contract
     network: {{ network }}

--- a/subgraphs/bridgeworld-stats/template.yaml
+++ b/subgraphs/bridgeworld-stats/template.yaml
@@ -57,3 +57,27 @@ dataSources:
         - event: NoPilgrimagesToFinish(indexed address)
           handler: handleNoPilgrimagesToFinish
       file: ./src/mappings/pilgrimage.ts
+  - name: Summoning
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      address: "{{ summoning_address }}"
+      abi: Summoning
+      startBlock: {{ summoning_start_block }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Token
+        - User
+        - UserToken
+      abis:
+        - name: Summoning
+          file: ../../node_modules/@treasure/subgraph-abis/src/Summoning.json
+      eventHandlers:
+        - event: SummoningStarted(indexed address,indexed uint256,indexed uint256,uint256)
+          handler: handleSummoningStarted
+        - event: SummoningFinished(indexed address,indexed uint256,indexed uint256,uint256)
+          handler: handleSummoningFinished
+      file: ./src/mappings/summoning.ts

--- a/subgraphs/bridgeworld-stats/tests/atlas-mine/atlas-mine.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/atlas-mine/atlas-mine.test.ts
@@ -41,6 +41,7 @@ test("atlas mine stats count deposits", () => {
     assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, statIds[i], "magicDepositCount", "1");
     assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, statIds[i], "magicDeposited", "500");
     assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, statIds[i], "activeAddressesCount", "1");
+    assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, statIds[i], "allAddressesCount", "1");
 
     // Assert all time intervals for lock period are created
     assert.fieldEquals(ATLAS_MIN_LOCK_STAT_ENTITY_TYPE, `${statIds[i]}-lock0`, "magicDepositCount", "1");
@@ -72,16 +73,19 @@ test("atlas mine stats count deposits", () => {
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "20220116-weekly", "magicDepositCount", "1");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "20220116-weekly", "magicDeposited", "100");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "20220116-weekly", "activeAddressesCount", "1");
+  assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "20220116-weekly", "allAddressesCount", "1");
 
   // Assert new monthly interval was created
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "202201-monthly", "magicDepositCount", "1");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "202201-monthly", "magicDeposited", "100");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "202201-monthly", "activeAddressesCount", "1");
+  assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "202201-monthly", "allAddressesCount", "1");
 
   // Assert yearly interval contains both deposits
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "2022-yearly", "magicDepositCount", "2");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "2022-yearly", "magicDeposited", "600");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "2022-yearly", "activeAddressesCount", "2");
+  assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "2022-yearly", "allAddressesCount", "2");
 });
 
 test("atlas mine stats count withrawals", () => {
@@ -107,7 +111,9 @@ test("atlas mine stats updates unique addresses on withdrawals", () => {
   handleWithdraw(withdrawEvent);
 
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "202201-monthly", "activeAddressesCount", "1");
+  assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "202201-monthly", "allAddressesCount", "1");
   assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "all-time", "activeAddressesCount", "0");
+  assert.fieldEquals(ATLAS_MINE_STAT_ENTITY_TYPE, "all-time", "allAddressesCount", "1");
 });
 
 test("atlas mine stats count harvests", () => {

--- a/subgraphs/bridgeworld-stats/tests/legion/legion.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/legion/legion.test.ts
@@ -1,0 +1,31 @@
+import { LEGION_ADDRESS } from "@treasure/constants";
+import { assert, clearStore, test } from "matchstick-as";
+
+import { handleLegionCreated } from "../../src/mappings/legion";
+import { createLegionCreatedEvent } from "./utils";
+
+const LEGION_ENTITY_TYPE = "Legion";
+
+test("legion is created", () => {
+  clearStore();
+
+  const legionCreatedEvent = createLegionCreatedEvent(1, 0, 4);
+  handleLegionCreated(legionCreatedEvent);
+
+  // Assert legion was created
+  const id = `${LEGION_ADDRESS.toHexString()}-0x1`;
+  assert.fieldEquals(LEGION_ENTITY_TYPE, id, "generation", "Genesis");
+  assert.fieldEquals(LEGION_ENTITY_TYPE, id, "rarity", "Common");
+  assert.fieldEquals(LEGION_ENTITY_TYPE, id, "name", "Genesis Common");
+});
+
+test("legion with custom name is created", () => {
+  clearStore();
+
+  const legionCreatedEvent = createLegionCreatedEvent(3476, 0, 0);
+  handleLegionCreated(legionCreatedEvent);
+
+  // Assert clocksnatcher was created
+  const id = `${LEGION_ADDRESS.toHexString()}-0xd94`;
+  assert.fieldEquals(LEGION_ENTITY_TYPE, id, "name", "Clocksnatcher");
+});

--- a/subgraphs/bridgeworld-stats/tests/legion/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/legion/utils.ts
@@ -1,0 +1,21 @@
+import { Address, ethereum } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+
+import { LegionCreated } from "../../generated/Legion Metadata Store/LegionMetadataStore";
+
+export function createLegionCreatedEvent(
+  tokenId: i32,
+  generation: i32,
+  rarity: i32
+): LegionCreated {
+  const event = changetype<LegionCreated>(newMockEvent());
+  event.parameters = [
+    new ethereum.EventParam("_owner", ethereum.Value.fromAddress(Address.zero())),
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),
+    new ethereum.EventParam("_generation", ethereum.Value.fromI32(generation)),
+    new ethereum.EventParam("_class", ethereum.Value.fromI32(0)),
+    new ethereum.EventParam("_rarity", ethereum.Value.fromI32(rarity))
+  ];
+
+  return event;
+}

--- a/subgraphs/bridgeworld-stats/tests/summoning/summoning.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/summoning/summoning.test.ts
@@ -42,10 +42,12 @@ test("summoning stats count summons started", () => {
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "interval", intervals[i]);
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "magicSpent", "300000000000000000000");
     assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "summonsStarted", "1");
     assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "activeAddressesCount", "1");
 
     // Assert all time intervals for legion type are created
+    assert.fieldEquals(SUMMONING_LEGION_STAT_ENTITY_TYPE, `${statIds[i]}-genesis-common`, "magicSpent", "300000000000000000000");
     assert.fieldEquals(SUMMONING_LEGION_STAT_ENTITY_TYPE, `${statIds[i]}-genesis-common`, "summonsStarted", "1");
   }
 
@@ -66,19 +68,25 @@ test("summoning stats count summons started", () => {
   handleSummoningStarted(summoningStartedEvent2);
   
   // Assert previous intervals are unaffected
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[0], "magicSpent", "300000000000000000000");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[0], "summonsStarted", "1");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[1], "magicSpent", "300000000000000000000");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[1], "summonsStarted", "1");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[2], "magicSpent", "300000000000000000000");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[2], "summonsStarted", "1");
 
   // Assert new weekly interval was created
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "20220116-weekly", "magicSpent", "300000000000000000000");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "20220116-weekly", "summonsStarted", "1");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "20220116-weekly", "activeAddressesCount", "1");
 
   // Assert new monthly interval was created
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "202201-monthly", "magicSpent", "300000000000000000000");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "202201-monthly", "summonsStarted", "1");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "202201-monthly", "activeAddressesCount", "1");
 
   // Assert yearly interval contains both deposits
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "2022-yearly", "magicSpent", "600000000000000000000");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "2022-yearly", "summonsStarted", "2");
   assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "2022-yearly", "activeAddressesCount", "2");
 });

--- a/subgraphs/bridgeworld-stats/tests/summoning/summoning.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/summoning/summoning.test.ts
@@ -1,0 +1,97 @@
+import { assert, clearStore, test } from "matchstick-as";
+
+import { handleSummoningFinished, handleSummoningStarted } from "../../src/mappings/summoning";
+import { createSummoningFinishedEvent, createSummoningStartedEvent } from "./utils";
+
+const SUMMONING_STAT_ENTITY_TYPE = "SummoningStat";
+const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";
+const USER_ADDRESS2 = "0x461950b159366edcd2bcbee8126d973ac49238e1";
+
+// Feb 9 22, 7:15
+const timestamp = 1644390900;
+const statIds = [
+  "20220209-0700-hourly",
+  "20220209-daily",
+  "20220206-weekly",
+  "202202-monthly",
+  "2022-yearly",
+  "all-time"
+];
+
+test("summoning stats count summons started", () => {
+  clearStore();
+
+  const summoningStartedEvent = createSummoningStartedEvent(timestamp, USER_ADDRESS);
+  handleSummoningStarted(summoningStartedEvent);
+
+  const intervals = [
+    "Hourly",
+    "Daily",
+    "Weekly",
+    "Monthly",
+    "Yearly",
+    "AllTime"
+  ];
+  
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "interval", intervals[i]);
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "summonsStarted", "1");
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "activeAddressesCount", "1");
+  }
+
+  // Assert start and end times are correct
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[0], "startTimestamp", "1644390000");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[0], "endTimestamp", "1644393599");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[1], "startTimestamp", "1644364800");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[1], "endTimestamp", "1644451199");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[2], "startTimestamp", "1644105600");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[2], "endTimestamp", "1644710399");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[3], "startTimestamp", "1643673600");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[3], "endTimestamp", "1646092799");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[4], "startTimestamp", "1640995200");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[4], "endTimestamp", "1672531199");
+  
+  // Jan 20 22, 23:15
+  const summoningStartedEvent2 = createSummoningStartedEvent(1642720500, USER_ADDRESS2);
+  handleSummoningStarted(summoningStartedEvent2);
+  
+  // Assert previous intervals are unaffected
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[0], "summonsStarted", "1");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[1], "summonsStarted", "1");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[2], "summonsStarted", "1");
+
+  // Assert new weekly interval was created
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "20220116-weekly", "summonsStarted", "1");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "20220116-weekly", "activeAddressesCount", "1");
+
+  // Assert new monthly interval was created
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "202201-monthly", "summonsStarted", "1");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "202201-monthly", "activeAddressesCount", "1");
+
+  // Assert yearly interval contains both deposits
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "2022-yearly", "summonsStarted", "2");
+  assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, "2022-yearly", "activeAddressesCount", "2");
+});
+
+test("summoning stats count summons finished", () => {
+  clearStore();
+
+  const summoningStartedEvent = createSummoningStartedEvent(timestamp, USER_ADDRESS);
+  handleSummoningStarted(summoningStartedEvent);
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "summonsStarted", "1");
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "activeAddressesCount", "1");
+  }
+
+  const summoningFinishedEvent = createSummoningFinishedEvent(timestamp, USER_ADDRESS);
+  handleSummoningFinished(summoningFinishedEvent);
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "summonsFinished", "1");
+    assert.fieldEquals(SUMMONING_STAT_ENTITY_TYPE, statIds[i], "activeAddressesCount", "0");
+  }
+});

--- a/subgraphs/bridgeworld-stats/tests/summoning/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/summoning/utils.ts
@@ -5,12 +5,14 @@ import { SummoningFinished, SummoningStarted } from "../../generated/Summoning/S
 
 export function createSummoningStartedEvent(
   timestamp: i32,
-  user: string
+  user: string,
+  tokenId: i32
 ): SummoningStarted {
   const event = changetype<SummoningStarted>(newMockEvent());
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
-    new ethereum.EventParam("_user", ethereum.Value.fromAddress(Address.fromString(user)))
+    new ethereum.EventParam("_user", ethereum.Value.fromAddress(Address.fromString(user))),
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId))
   ];
 
   return event;
@@ -18,12 +20,16 @@ export function createSummoningStartedEvent(
 
 export function createSummoningFinishedEvent(
   timestamp: i32,
-  user: string
+  user: string,
+  returnedId: i32,
+  newTokenId: i32
 ): SummoningFinished {
   const event = changetype<SummoningFinished>(newMockEvent());
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
-    new ethereum.EventParam("_user", ethereum.Value.fromAddress(Address.fromString(user)))
+    new ethereum.EventParam("_user", ethereum.Value.fromAddress(Address.fromString(user))),
+    new ethereum.EventParam("_returnedId", ethereum.Value.fromI32(returnedId)),
+    new ethereum.EventParam("_newTokenId", ethereum.Value.fromI32(newTokenId))
   ];
 
   return event;

--- a/subgraphs/bridgeworld-stats/tests/summoning/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/summoning/utils.ts
@@ -1,0 +1,30 @@
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+
+import { SummoningFinished, SummoningStarted } from "../../generated/Summoning/Summoning";
+
+export function createSummoningStartedEvent(
+  timestamp: i32,
+  user: string
+): SummoningStarted {
+  const event = changetype<SummoningStarted>(newMockEvent());
+  event.block.timestamp = BigInt.fromI32(timestamp);
+  event.parameters = [
+    new ethereum.EventParam("_user", ethereum.Value.fromAddress(Address.fromString(user)))
+  ];
+
+  return event;
+}
+
+export function createSummoningFinishedEvent(
+  timestamp: i32,
+  user: string
+): SummoningFinished {
+  const event = changetype<SummoningFinished>(newMockEvent());
+  event.block.timestamp = BigInt.fromI32(timestamp);
+  event.parameters = [
+    new ethereum.EventParam("_user", ethereum.Value.fromAddress(Address.fromString(user)))
+  ];
+
+  return event;
+}


### PR DESCRIPTION
Closes #35 

Adds summoning stats (with time period filters):
- $MAGIC spent on summons
- Summons started
- Summons finished
- Active summoning wallets
- All summoning wallets
- $MAGIC spent by Legion generation/rarity
- Summons started/finished by Legion generation/rarity
- Summoning results by Legion rarity

Also added a value to track all Atlas Mine wallets (not just the active ones)