### PR TITLE
[smolverse] fix smol token ipfs.cat call

### DIFF
--- a/subgraphs/smolverse/src/helpers/json.ts
+++ b/subgraphs/smolverse/src/helpers/json.ts
@@ -9,9 +9,12 @@ export function getJsonStringValue(json: JSON, attribute: string): string | null
 }
 
 export function getIpfsJson(path: string): JSON | null {
-  const data = ipfs.cat(path);
+  const normalizedPath = path
+    .replace("ipfs://", "")
+    .replace("https://treasure-marketplace.mypinata.cloud/ipfs/", "");
+  const data = ipfs.cat(normalizedPath);
   if (!data) {
-    log.error("Missing IPFS data at path: {}", [path]);
+    log.error("Missing IPFS data at path: {}", [normalizedPath]);
     return null;
   }
 
@@ -25,5 +28,5 @@ export function getCollectionJson(collection: Collection, path: string): JSON | 
     return null;
   }
 
-  return getIpfsJson(`${(baseUri as string).replace("ipfs://", "")}${path}`);
+  return getIpfsJson(`${baseUri as string}${path}`);
 }


### PR DESCRIPTION
Observed error in the subgraph logs:

```
Missing IPFS data at path: https://treasure-marketplace.mypinata.cloud/ipfs/QmeEnvD1QimFbJNigsxwrsfQPw1JuDiFVtBdPAGR3zT5kh/0, data_source: Smol Brains Land, block_hash: 0xd5074f968b1015674d4e32dcc5f1e0850a507827153b7c2c8e28a76ca13c87cb, block_number: 3267140
```

`ipfs.cat` shouldn't be a full URL, just the IPFS hash and path