### PR TITLE
[smolverse] fix parsing attributes with numeric values

### DIFF
--- a/subgraphs/smolverse/schema.graphql
+++ b/subgraphs/smolverse/schema.graphql
@@ -92,5 +92,6 @@ type Seeded @entity {
 type Claim @entity {
   id: ID!
   status: ClaimStatus!
+  startTime: BigInt!
   reward: Token
 }

--- a/subgraphs/smolverse/src/helpers/metadata.ts
+++ b/subgraphs/smolverse/src/helpers/metadata.ts
@@ -1,4 +1,4 @@
-import { log, TypedMap } from "@graphprotocol/graph-ts";
+import { JSONValueKind, log, TypedMap } from "@graphprotocol/graph-ts";
 import {
   SMOL_BODIES_ADDRESS,
   SMOL_BODIES_PETS_ADDRESS,
@@ -89,9 +89,9 @@ export function updateTokenMetadata(token: Token, data: JSON): void {
         continue;
       }
 
-      attributes.push(
-        getOrCreateAttribute(collection, token, nameData.toString(), valueData.toString())
-      );
+      const name = nameData.toString();
+      const value = valueData.kind === JSONValueKind.NUMBER ? valueData.toI64().toString() : valueData.toString();
+      attributes.push(getOrCreateAttribute(collection, token, name, value));
     }
     
     token.attributes = attributes.map<string>((attribute) => attribute.id);

--- a/subgraphs/smolverse/src/mappings/smol-farm.ts
+++ b/subgraphs/smolverse/src/mappings/smol-farm.ts
@@ -53,6 +53,7 @@ export function handleStartClaiming(event: StartClaiming): void {
   const claimId = `${stakedTokenId}-${random.id}`;
   const claim = new Claim(claimId);
   claim.status = "Started";
+  claim.startTime = event.block.timestamp;
   claim.save();
 
   random._claimId = claim.id;

--- a/subgraphs/smolverse/tests/erc721/erc721.test.ts
+++ b/subgraphs/smolverse/tests/erc721/erc721.test.ts
@@ -25,6 +25,10 @@ const mockTokenData = json.fromBytes(
         {
           "trait_type": "Body",
           "value": "brown"
+        },
+        {
+          "trait_type": "Head Size",
+          "value": 5
         }
       ]
     }


### PR DESCRIPTION
Adds timestamp to Smol Farm claims

Fixes observed error in subgraph logs:

```
Subgraph instance failed to run: Mapping aborted at ~lib/@graphprotocol/graph-ts/common/value.ts, line 280, column 5, with message: JSON value is not a string. wasm backtrace: 0: 0x2b64 - <unknown>!~lib/string/String#toLowerCase 1: 0x466a - <unknown>!src/mappings/erc721/handleTransfer 2: 0x4dc8 - <unknown>!../../node_modules/@graphprotocol/graph-ts/global/global/id_of_type in handler `handleTransfer` at block #3163503 (e157d799fceb6a140f2186c1333d31d5df611e0c7c7370dbebf10fd633b1b1fb), code: SubgraphSyncingFailure
```

Sorry kind of flying blind here with no metadata on testnet 😁 I think this should do it! Utilizing code from `treasure-marketplace-subgraph` and tested locally with a numeric JSON value.