### PR TITLE
[bridgeworld]  Add summoning result to finished summon entity

### DIFF
--- a/subgraphs/bridgeworld/schema.graphql
+++ b/subgraphs/bridgeworld/schema.graphql
@@ -212,6 +212,7 @@ type Summon @entity {
   random: Random!
   status: Status!
   token: Token!
+  resultToken: Token
   user: User!
 }
 

--- a/subgraphs/bridgeworld/src/mappings/summoning.ts
+++ b/subgraphs/bridgeworld/src/mappings/summoning.ts
@@ -80,6 +80,7 @@ export function handleSummoningFinished(event: SummoningFinished): void {
 
   summon.id = `${summon.id}-${summon.random}`;
   summon.status = "Finished";
+  summon.resultToken = metadata.id.replace("-metadata", "");
   summon.save();
 
   store.remove("Summon", id);

--- a/subgraphs/bridgeworld/tests/helpers/constants.ts
+++ b/subgraphs/bridgeworld/tests/helpers/constants.ts
@@ -6,6 +6,7 @@ export const LEGION_METADATA_STORE_ADDRESS =
   "0x99193ee9229b833d2aa4dbbda697c6600b944286";
 export const PILGRIMAGE_ADDRESS = "0x088613c6bbb951c9796ba3bb42a1f310fb209fbd";
 export const QUESTING_ADDRESS = "0xda3cad5e4f40062ceca6c1b979766bc0baed8e33";
+export const SUMMONING_ADDRESS = "0xc8dbdc58289474ab3e01568eb5f88f440bde6b46";
 export const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";
 
 // Entity names
@@ -13,6 +14,7 @@ export const BROKEN_ENTITY_TYPE = "Broken";
 export const CRAFT_ENTITY_TYPE = "Craft";
 export const LEGION_INFO_ENTITY_TYPE = "LegionInfo";
 export const QUEST_ENTITY_TYPE = "Quest";
+export const SUMMON_ENTITY_TYPE = "Summon";
 export const TOKEN_ENTITY_TYPE = "Token";
 
 // Enums

--- a/subgraphs/bridgeworld/tests/helpers/summoning.ts
+++ b/subgraphs/bridgeworld/tests/helpers/summoning.ts
@@ -1,0 +1,47 @@
+import { newMockEvent } from "matchstick-as/assembly";
+import { Address, ethereum } from "@graphprotocol/graph-ts";
+
+import { SUMMONING_ADDRESS } from ".";
+import { SummoningFinished, SummoningStarted } from "../../generated/Summoning/Summoning";
+
+export const createSummoningStartedEvent = (
+  user: string,
+  tokenId: i32,
+  requestId: i32,
+  finishTime: i32
+): SummoningStarted => {
+  const newEvent = changetype<SummoningStarted>(newMockEvent());
+  newEvent.address = Address.fromString(SUMMONING_ADDRESS);
+  newEvent.parameters = [
+    new ethereum.EventParam(
+      "_user",
+      ethereum.Value.fromAddress(Address.fromString(user))
+    ),
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),
+    new ethereum.EventParam("_requestId", ethereum.Value.fromI32(requestId)),
+    new ethereum.EventParam("_finishTime", ethereum.Value.fromI32(finishTime))
+  ];
+
+  return newEvent;
+};
+
+export const createdSummoningFinishedEvent = (
+  user: string,
+  returnedId: i32,
+  newTokenId: i32,
+  newTokenSummoningCooldown: i32
+): SummoningFinished => {
+  const newEvent = changetype<SummoningFinished>(newMockEvent());
+  newEvent.address = Address.fromString(SUMMONING_ADDRESS);
+  newEvent.parameters = [
+    new ethereum.EventParam(
+      "_user",
+      ethereum.Value.fromAddress(Address.fromString(user))
+    ),
+    new ethereum.EventParam("_returnedId", ethereum.Value.fromI32(returnedId)),
+    new ethereum.EventParam("_newTokenId", ethereum.Value.fromI32(newTokenId)),
+    new ethereum.EventParam("_newTokenSummoningCooldown", ethereum.Value.fromI32(newTokenSummoningCooldown))
+  ];
+
+  return newEvent;
+};

--- a/subgraphs/bridgeworld/tests/summoning.test.ts
+++ b/subgraphs/bridgeworld/tests/summoning.test.ts
@@ -1,0 +1,76 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { LEGION_ADDRESS } from "@treasure/constants";
+import { assert, logStore, test } from "matchstick-as";
+import { handleLegionCreated, handleTransfer } from "../src/mappings/legion";
+import { handleRandomRequest } from "../src/mappings/randomizer";
+import {
+  handleSummoningFinished,
+  handleSummoningStarted
+} from "../src/mappings/summoning";
+import {
+  createLegionCreatedEvent,
+  createLegionTransferEvent,
+  createRandomRequestEvent,
+  LEGION_INFO_ENTITY_TYPE,
+  SUMMON_ENTITY_TYPE,
+  TOKEN_ENTITY_TYPE,
+  USER_ADDRESS
+} from "./helpers";
+import {
+  createdSummoningFinishedEvent,
+  createSummoningStartedEvent
+} from "./helpers/summoning";
+
+test("summon is started and finished with result token", () => {
+  const randomRequestEvent = createRandomRequestEvent(0, 1);
+  handleRandomRequest(randomRequestEvent);
+
+  const mintEvent = createLegionTransferEvent(
+    Address.zero().toHexString(),
+    USER_ADDRESS,
+    7
+  );
+  handleTransfer(mintEvent);
+
+  const legionCreatedEvent = createLegionCreatedEvent(USER_ADDRESS, 7, 0, 6, 2);
+  handleLegionCreated(legionCreatedEvent);
+
+  const summoningStartedEvent = createSummoningStartedEvent(
+    USER_ADDRESS,
+    7,
+    0,
+    1643659676
+  );
+  handleSummoningStarted(summoningStartedEvent);
+
+  const id = `${LEGION_ADDRESS.toHexString()}-0x7`;
+  assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "category", "Legion");
+
+  const metadata = `${id}-metadata`;
+  assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "summons", "1");
+
+  const summon = `${summoningStartedEvent.address.toHexString()}-0x7`;
+  assert.fieldEquals(SUMMON_ENTITY_TYPE, summon, "token", id);
+  assert.fieldEquals(SUMMON_ENTITY_TYPE, summon, "status", "Idle");
+
+  const newMintEvent = createLegionTransferEvent(
+    Address.zero().toHexString(),
+    USER_ADDRESS,
+    1
+  );
+  handleTransfer(newMintEvent);
+
+  const newLegionCreatedEvent = createLegionCreatedEvent(USER_ADDRESS, 1, 1, 1, 4);
+  handleLegionCreated(newLegionCreatedEvent);
+
+  const summoningFinishedEvent = createdSummoningFinishedEvent(
+    USER_ADDRESS,
+    7,
+    1,
+    0
+  );
+  handleSummoningFinished(summoningFinishedEvent);
+
+  assert.fieldEquals(SUMMON_ENTITY_TYPE, summon, "status", "Finished");
+  assert.fieldEquals(SUMMON_ENTITY_TYPE, summon, "resultToken", `${LEGION_ADDRESS.toHexString()}-0x1`);
+});

--- a/subgraphs/bridgeworld/tests/summoning.test.ts
+++ b/subgraphs/bridgeworld/tests/summoning.test.ts
@@ -71,6 +71,6 @@ test("summon is started and finished with result token", () => {
   );
   handleSummoningFinished(summoningFinishedEvent);
 
-  assert.fieldEquals(SUMMON_ENTITY_TYPE, summon, "status", "Finished");
-  assert.fieldEquals(SUMMON_ENTITY_TYPE, summon, "resultToken", `${LEGION_ADDRESS.toHexString()}-0x1`);
+  assert.fieldEquals(SUMMON_ENTITY_TYPE, `${summon}-0x0`, "status", "Finished");
+  assert.fieldEquals(SUMMON_ENTITY_TYPE, `${summon}-0x0`, "resultToken", `${LEGION_ADDRESS.toHexString()}-0x1`);
 });


### PR DESCRIPTION
Closes #50 

- Adds new `resultToken` field to finished `Summon` entities