### PR TITLE
[smolverse] track collection token and staked token counts

### DIFF
--- a/subgraphs/smolverse/schema.graphql
+++ b/subgraphs/smolverse/schema.graphql
@@ -30,8 +30,8 @@ type Collection @entity {
   name: String!
   standard: TokenStandard
   baseUri: String
-  tokensCount: BigInt!
-  stakedTokensCount: BigInt!
+  tokensCount: Int!
+  stakedTokensCount: Int!
   tokens: [Token!]! @derivedFrom(field: "collection")
   attributes: [Attribute!] @derivedFrom(field: "collection")
 }

--- a/subgraphs/smolverse/schema.graphql
+++ b/subgraphs/smolverse/schema.graphql
@@ -27,12 +27,11 @@ type Collection @entity {
   "Internal for tracking attributes for a collection"
   _attributeIds: [String!]!
 
-  "Internal for tracking tokenIds minted for a collection"
-  _tokenIds: [String!]!
-
   name: String!
   standard: TokenStandard
   baseUri: String
+  tokensCount: BigInt!
+  stakedTokensCount: BigInt!
   tokens: [Token!]! @derivedFrom(field: "collection")
   attributes: [Attribute!] @derivedFrom(field: "collection")
 }
@@ -59,7 +58,6 @@ type Token @entity {
   description: String
   image: String
   owner: User
-  stakedTokens: [StakedToken!] @derivedFrom(field: "token")
 }
 
 type StakedToken @entity {

--- a/subgraphs/smolverse/src/helpers/metadata.ts
+++ b/subgraphs/smolverse/src/helpers/metadata.ts
@@ -21,7 +21,7 @@ ATTRIBUTE_PERCENTAGE_THRESHOLDS.set(SMOL_BRAINS_LAND_ADDRESS.toHexString(), 4_22
 const shouldUpdateAttributePercentages = (collection: Collection): boolean => {
   const threshold = ATTRIBUTE_PERCENTAGE_THRESHOLDS.getEntry(collection.id);
   const thresholdValue = threshold ? threshold.value : 0;
-  return collection.tokensCount.toI32() >= thresholdValue;
+  return collection.tokensCount >= thresholdValue;
 };
 
 export function updateAttributePercentages(collection: Collection): void {
@@ -31,7 +31,6 @@ export function updateAttributePercentages(collection: Collection): void {
   }
 
   const attributeIds = collection._attributeIds;
-  const totalTokens = collection.tokensCount.toI32();
   const totalAttributes = attributeIds.length;
   for (let i = 0; i < totalAttributes; i++) {
     const attribute = Attribute.load(attributeIds[i]);
@@ -42,7 +41,7 @@ export function updateAttributePercentages(collection: Collection): void {
 
     attribute.percentage =
       toBigDecimal(attribute._tokenIds.length)
-        .div(toBigDecimal(totalTokens))
+        .div(toBigDecimal(collection.tokensCount))
         .truncate(10);
     attribute.save();
   }

--- a/subgraphs/smolverse/src/helpers/metadata.ts
+++ b/subgraphs/smolverse/src/helpers/metadata.ts
@@ -21,7 +21,7 @@ ATTRIBUTE_PERCENTAGE_THRESHOLDS.set(SMOL_BRAINS_LAND_ADDRESS.toHexString(), 4_22
 const shouldUpdateAttributePercentages = (collection: Collection): boolean => {
   const threshold = ATTRIBUTE_PERCENTAGE_THRESHOLDS.getEntry(collection.id);
   const thresholdValue = threshold ? threshold.value : 0;
-  return collection._tokenIds.length >= thresholdValue;
+  return collection.tokensCount.toI32() >= thresholdValue;
 };
 
 export function updateAttributePercentages(collection: Collection): void {
@@ -31,7 +31,7 @@ export function updateAttributePercentages(collection: Collection): void {
   }
 
   const attributeIds = collection._attributeIds;
-  const totalTokens = collection._tokenIds.length;
+  const totalTokens = collection.tokensCount.toI32();
   const totalAttributes = attributeIds.length;
   for (let i = 0; i < totalAttributes; i++) {
     const attribute = Attribute.load(attributeIds[i]);

--- a/subgraphs/smolverse/src/helpers/models.ts
+++ b/subgraphs/smolverse/src/helpers/models.ts
@@ -4,6 +4,7 @@ import { Attribute, Collection, Random, Seeded, Token, User } from "../../genera
 import { getNameForCollection } from "./collections";
 import { TOKEN_STANDARD_ERC721 } from "./constants";
 import { getAttributeId, getCollectionId, getRandomId, getSeededId, getTokenId } from "./ids";
+import { ZERO_BI } from "./number";
 
 export function getOrCreateUser(id: string): User {
   let user = User.load(id);
@@ -36,7 +37,11 @@ export function getOrCreateAttribute(
     collection.save();
   }
 
-  attribute._tokenIds = attribute._tokenIds.concat([token.tokenId.toString()]);
+  const tokenIdString = token.tokenId.toString();
+  if (!attribute._tokenIds.includes(tokenIdString)) {
+    attribute._tokenIds = attribute._tokenIds.concat([tokenIdString]);
+  }
+
   attribute.save();
 
   return attribute;
@@ -51,7 +56,8 @@ export function getOrCreateCollection(address: Address): Collection {
     collection.name = getNameForCollection(address);
     collection.standard = TOKEN_STANDARD_ERC721;
     collection._attributeIds = [];
-    collection._tokenIds = [];
+    collection.tokensCount = ZERO_BI;
+    collection.tokensCount = ZERO_BI;
     collection.save();
   }
 
@@ -68,7 +74,7 @@ export function getOrCreateToken(collection: Collection, tokenId: BigInt): Token
     token.tokenId = tokenId;
     token.save();
 
-    collection._tokenIds = collection._tokenIds.concat([tokenId.toString()]);
+    collection.tokensCount = collection.tokensCount.plus(BigInt.fromI32(1));
     collection.save();
   }
 

--- a/subgraphs/smolverse/src/helpers/models.ts
+++ b/subgraphs/smolverse/src/helpers/models.ts
@@ -4,7 +4,6 @@ import { Attribute, Collection, Random, Seeded, Token, User } from "../../genera
 import { getNameForCollection } from "./collections";
 import { TOKEN_STANDARD_ERC721 } from "./constants";
 import { getAttributeId, getCollectionId, getRandomId, getSeededId, getTokenId } from "./ids";
-import { ZERO_BI } from "./number";
 
 export function getOrCreateUser(id: string): User {
   let user = User.load(id);
@@ -56,8 +55,6 @@ export function getOrCreateCollection(address: Address): Collection {
     collection.name = getNameForCollection(address);
     collection.standard = TOKEN_STANDARD_ERC721;
     collection._attributeIds = [];
-    collection.tokensCount = ZERO_BI;
-    collection.tokensCount = ZERO_BI;
     collection.save();
   }
 
@@ -74,7 +71,7 @@ export function getOrCreateToken(collection: Collection, tokenId: BigInt): Token
     token.tokenId = tokenId;
     token.save();
 
-    collection.tokensCount = collection.tokensCount.plus(BigInt.fromI32(1));
+    collection.tokensCount += 1;
     collection.save();
   }
 

--- a/subgraphs/smolverse/src/helpers/number.ts
+++ b/subgraphs/smolverse/src/helpers/number.ts
@@ -1,7 +1,4 @@
-import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
-
-export const ZERO_BI = BigInt.fromI32(0);
-export const ONE_BI = BigInt.fromI32(1);
+import { BigDecimal } from "@graphprotocol/graph-ts";
 
 export function toBigDecimal(value: number): BigDecimal {
   return BigDecimal.fromString(value.toString());

--- a/subgraphs/smolverse/src/helpers/number.ts
+++ b/subgraphs/smolverse/src/helpers/number.ts
@@ -1,4 +1,7 @@
-import { BigDecimal } from "@graphprotocol/graph-ts";
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+
+export const ZERO_BI = BigInt.fromI32(0);
+export const ONE_BI = BigInt.fromI32(1);
 
 export function toBigDecimal(value: number): BigDecimal {
   return BigDecimal.fromString(value.toString());

--- a/subgraphs/smolverse/src/helpers/token-id.ts
+++ b/subgraphs/smolverse/src/helpers/token-id.ts
@@ -7,7 +7,7 @@ export function getTokenName(tokenId: BigInt): string {
     case 1: return "Moon Rock";
     case 2: return "Stardust";
     case 3: return "Comet Shard";
-    case 4: return "Gold";
+    case 4: return "Lunar Gold";
     case 5: return "Alien Relic";
     default:
       log.error("Token name not handled: {}", [id.toString()]);

--- a/subgraphs/smolverse/src/mappings/common.ts
+++ b/subgraphs/smolverse/src/mappings/common.ts
@@ -10,6 +10,7 @@ import { getCollectionId, getStakedTokenId } from "../helpers/ids";
 import { getIpfsJson } from "../helpers/json";
 import { updateTokenMetadata } from "../helpers/metadata";
 import { getOrCreateCollection, getOrCreateToken, getOrCreateUser } from "../helpers/models";
+import { ONE_BI } from "../helpers/number";
 import { isMint } from "../helpers/utils";
 
 export function handleTransfer(
@@ -71,11 +72,15 @@ export function handleStake(
   stakedToken.owner = owner.id;
   stakedToken.stakeTime = stakeTime;
   stakedToken.save();
+
+  collection.stakedTokensCount = collection.stakedTokensCount.plus(ONE_BI);
+  collection.save();
 }
 
 export function handleUnstake(address: Address, tokenId: BigInt, location: string): void {
+  const collection = getOrCreateCollection(address);
   const id = getStakedTokenId(
-    getCollectionId(address),
+    collection.id,
     tokenId,
     location
   );
@@ -93,5 +98,8 @@ export function handleUnstake(address: Address, tokenId: BigInt, location: strin
   }
 
   store.remove("StakedToken", id);
+
+  collection.stakedTokensCount = collection.stakedTokensCount.minus(ONE_BI);
+  collection.save();
 }
 

--- a/subgraphs/smolverse/src/mappings/common.ts
+++ b/subgraphs/smolverse/src/mappings/common.ts
@@ -10,7 +10,6 @@ import { getCollectionId, getStakedTokenId } from "../helpers/ids";
 import { getIpfsJson } from "../helpers/json";
 import { updateTokenMetadata } from "../helpers/metadata";
 import { getOrCreateCollection, getOrCreateToken, getOrCreateUser } from "../helpers/models";
-import { ONE_BI } from "../helpers/number";
 import { isMint } from "../helpers/utils";
 
 export function handleTransfer(
@@ -73,7 +72,7 @@ export function handleStake(
   stakedToken.stakeTime = stakeTime;
   stakedToken.save();
 
-  collection.stakedTokensCount = collection.stakedTokensCount.plus(ONE_BI);
+  collection.stakedTokensCount += 1;
   collection.save();
 }
 
@@ -99,7 +98,7 @@ export function handleUnstake(address: Address, tokenId: BigInt, location: strin
 
   store.remove("StakedToken", id);
 
-  collection.stakedTokensCount = collection.stakedTokensCount.minus(ONE_BI);
+  collection.stakedTokensCount -= 1;
   collection.save();
 }
 

--- a/subgraphs/smolverse/tests/smol-farm/smol-farm.test.ts
+++ b/subgraphs/smolverse/tests/smol-farm/smol-farm.test.ts
@@ -5,15 +5,27 @@ import { Collection, StakedToken, Token, User } from "../../generated/schema";
 
 import { getCollectionId, getStakedTokenId, getTokenId } from "../../src/helpers/ids";
 import { handleRandomRequest } from "../../src/mappings/randomizer";
-import { handleRewardClaimed, handleSmolStaked, handleSmolUnstaked, handleStartClaiming } from "../../src/mappings/smol-farm";
+import {
+  handleRewardClaimed,
+  handleSmolStaked,
+  handleSmolUnstaked,
+  handleStartClaiming
+} from "../../src/mappings/smol-farm";
 import { createRandomRequestEvent } from "../randomizer/utils";
-import { createRewardClaimedEvent, createSmolStakedEvent, createSmolUnstakedEvent, createStartClaimingEvent, getClaimId } from "./utils";
-
-const CLAIM_ENTITY_TYPE = "Claim";
-const COLLECTION_ENTITY_TYPE = "Collection";
-const STAKED_TOKEN_ENTITY_TYPE = "StakedToken";
-const TOKEN_ENTITY_TYPE = "Token";
-const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";
+import {
+  CLAIM_ENTITY_TYPE,
+  COLLECTION_ENTITY_TYPE,
+  STAKED_TOKEN_ENTITY_TYPE,
+  TOKEN_ENTITY_TYPE,
+  USER_ADDRESS
+} from "../utils";
+import {
+  createRewardClaimedEvent,
+  createSmolStakedEvent,
+  createSmolUnstakedEvent,
+  createStartClaimingEvent,
+  getClaimId
+} from "./utils";
 
 test("staked token is created", () => {
   clearStore();
@@ -28,12 +40,13 @@ test("staked token is created", () => {
   assert.assertNotNull(user);
 
   // Assert collection was created
-  const collection = Collection.load(smolStakedEvent.params._smolAddress.toHexString()) as Collection;
-  assert.assertNotNull(collection);
+  const address = smolStakedEvent.params._smolAddress.toHexString();
+  assert.fieldEquals(COLLECTION_ENTITY_TYPE, address, "tokensCount", "1");
+  assert.fieldEquals(COLLECTION_ENTITY_TYPE, address, "stakedTokensCount", "1");
 
   // Assert token was created
-  const token = Token.load(getTokenId(collection, BigInt.fromI32(tokenId))) as Token;
-  assert.stringEquals(token.collection, collection.id);
+  const token = Token.load(getTokenId(Collection.load(address) as Collection, BigInt.fromI32(tokenId))) as Token;
+  assert.stringEquals(token.collection, address);
   assert.bigIntEquals(token.tokenId, BigInt.fromI32(tokenId));
 
   // Assert staked token was created
@@ -57,18 +70,23 @@ test("unstaked token is removed", () => {
   handleSmolStaked(smolStakedEvent);
 
   // Assert staked token was created
+  const address = getCollectionId(smolStakedEvent.params._smolAddress);
   const stakedTokenId = getStakedTokenId(
-    getCollectionId(smolStakedEvent.params._smolAddress),
+    address,
     BigInt.fromI32(tokenId),
     "Farm"
   );
   assert.assertNotNull(StakedToken.load(stakedTokenId));
+  assert.fieldEquals(COLLECTION_ENTITY_TYPE, address, "tokensCount", "1");
+  assert.fieldEquals(COLLECTION_ENTITY_TYPE, address, "stakedTokensCount", "1");
 
   const smolUnstakedEvent = createSmolUnstakedEvent(USER_ADDRESS, tokenId);
   handleSmolUnstaked(smolUnstakedEvent);
 
   // Assert staked token was removed
   assert.assertNull(StakedToken.load(stakedTokenId));
+  assert.fieldEquals(COLLECTION_ENTITY_TYPE, address, "tokensCount", "1");
+  assert.fieldEquals(COLLECTION_ENTITY_TYPE, address, "stakedTokensCount", "0");
 });
 
 test("staked token claim is started", () => {

--- a/subgraphs/smolverse/tests/smol-farm/smol-farm.test.ts
+++ b/subgraphs/smolverse/tests/smol-farm/smol-farm.test.ts
@@ -137,7 +137,7 @@ test("staked token claim is completed", () => {
 
   // Assert reward token was created
   const rewardTokenId = `${SMOL_TREASURES_ADDRESS.toHexString()}-0x4`;
-  assert.fieldEquals(TOKEN_ENTITY_TYPE, rewardTokenId, "name", "Gold");
+  assert.fieldEquals(TOKEN_ENTITY_TYPE, rewardTokenId, "name", "Lunar Gold");
 
   // Assert claim was completed
   const claimId = getClaimId(

--- a/subgraphs/smolverse/tests/utils.ts
+++ b/subgraphs/smolverse/tests/utils.ts
@@ -1,5 +1,7 @@
 export const ATTRIBUTE_ENTITY_TYPE = "Attribute";
+export const CLAIM_ENTITY_TYPE = "Claim";
 export const COLLECTION_ENTITY_TYPE = "Collection";
+export const STAKED_TOKEN_ENTITY_TYPE = "StakedToken";
 export const TOKEN_ENTITY_TYPE = "Token";
 
 export const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";


### PR DESCRIPTION
Closes #60 

Changes to support the staked token percentage meter in Smolverse:
- Replaces token ID string tracker with a simple token counter
- Adds staked tokens count