### PR TITLE
[smolverse] various fixes for smolverse prod deploy

### DIFF
--- a/packages/config/src/arbitrum-testnet.json
+++ b/packages/config/src/arbitrum-testnet.json
@@ -27,6 +27,7 @@
   "questing_start_block": 8568745,
   "randomizer_address": "0xdEC6641458EeF4f7fe70101E77935D4e9d431F64",
   "randomizer_start_block": 8568594,
+  "randomizer_smol_farm_start_block": 9616731,
   "summoning_address": "0x9d012712d24C90DDEd4574430B9e6065183896BE",
   "summoning_start_block": 8568698,
   "treasure_address": "0x6333F38F98f5c46dA6F873aCbF25DCf8748DDc2c",

--- a/packages/config/src/arbitrum.json
+++ b/packages/config/src/arbitrum.json
@@ -26,7 +26,7 @@
   "questing_address": "0xDA3caD5e4F40062CECa6c1B979766BC0BAed8e33",
   "questing_start_block": 2416540,
   "randomizer_address": "0x8e79c8607a28fe1EC3527991C89F1d9E36D1bAd9",
-  "randomizer_start_block": 2416540,
+  "randomizer_start_block": 4955965,
   "summoning_address": "0xC8dbDC58289474AB3E01568Eb5f88f440BDE6B46",
   "summoning_start_block": 2416540,
   "treasure_address": "0xEBba467eCB6b21239178033189CeAE27CA12EaDf",

--- a/packages/config/src/arbitrum.json
+++ b/packages/config/src/arbitrum.json
@@ -27,6 +27,7 @@
   "questing_start_block": 2416540,
   "randomizer_address": "0x8e79c8607a28fe1EC3527991C89F1d9E36D1bAd9",
   "randomizer_start_block": 4955965,
+  "randomizer_smol_farm_start_block": 6399249,
   "summoning_address": "0xC8dbDC58289474AB3E01568Eb5f88f440BDE6B46",
   "summoning_start_block": 2416540,
   "treasure_address": "0xEBba467eCB6b21239178033189CeAE27CA12EaDf",

--- a/subgraphs/smolverse/schema.graphql
+++ b/subgraphs/smolverse/schema.graphql
@@ -55,6 +55,7 @@ type _LandMetadata @entity {
   attributes: [Attribute!]!
   description: String
   image: String
+  video: String
 }
 
 type Token @entity {
@@ -65,6 +66,7 @@ type Token @entity {
   attributes: [Attribute!]!
   description: String
   image: String
+  video: String
   owner: User
 }
 

--- a/subgraphs/smolverse/src/helpers/json.ts
+++ b/subgraphs/smolverse/src/helpers/json.ts
@@ -1,32 +1,32 @@
-import { ipfs, json, JSONValue, log, TypedMap } from "@graphprotocol/graph-ts";
-import { Collection } from "../../generated/schema";
+import { ipfs, json, JSONValue, JSONValueKind, log, TypedMap } from "@graphprotocol/graph-ts";
+
+const MAX_RETRIES = 2;
 
 export type JSON = TypedMap<string, JSONValue>;
 
 export function getJsonStringValue(json: JSON, attribute: string): string | null {
-  const value = json.get(attribute);
-  return value ? value.toString() : null;
+  const valueData = json.get(attribute);
+  if (!valueData) {
+    return null;
+  }
+
+  return valueData.kind === JSONValueKind.NUMBER ? valueData.toI64().toString() : valueData.toString();
 }
 
-export function getIpfsJson(path: string): JSON | null {
+export function getIpfsJson(path: string, retries: i32 = 0): JSON | null {
   const normalizedPath = path
     .replace("ipfs://", "")
     .replace("https://treasure-marketplace.mypinata.cloud/ipfs/", "");
   const data = ipfs.cat(normalizedPath);
   if (!data) {
-    log.error("Missing IPFS data at path: {}", [normalizedPath]);
-    return null;
+    if (retries > MAX_RETRIES) {
+      log.error("[json] IPFS data not found, max retries: {}", [normalizedPath]);
+      return null;
+    }
+
+    log.warning("[json] IPFS data not found, retry: {}", [normalizedPath])
+    return getIpfsJson(path, retries + 1);
   }
 
   return json.fromBytes(data).toObject();
-}
-
-export function getCollectionJson(collection: Collection, path: string): JSON | null {
-  const baseUri = collection.baseUri;
-  if (!baseUri) {
-    log.error("Unknown base URI for collection: {}", [collection.id]);
-    return null;
-  }
-
-  return getIpfsJson(`${baseUri as string}${path}`);
 }

--- a/subgraphs/smolverse/src/helpers/metadata.ts
+++ b/subgraphs/smolverse/src/helpers/metadata.ts
@@ -80,6 +80,11 @@ export function updateTokenMetadata(token: Token, data: JSON): void {
     token.image = image as string;
   }
 
+  const video = getJsonStringValue(data, "video");
+  if (video) {
+    token.video = video as string;
+  }
+
   // Parse attributes
   const attributesData = data.get("attributes");
   if (attributesData) {

--- a/subgraphs/smolverse/src/helpers/metadata.ts
+++ b/subgraphs/smolverse/src/helpers/metadata.ts
@@ -1,4 +1,4 @@
-import { JSONValueKind, log, TypedMap } from "@graphprotocol/graph-ts";
+import { log, TypedMap } from "@graphprotocol/graph-ts";
 import {
   SMOL_BODIES_ADDRESS,
   SMOL_BODIES_PETS_ADDRESS,
@@ -11,7 +11,6 @@ import { Attribute, Collection, Token } from "../../generated/schema";
 import { getJsonStringValue, JSON } from "./json";
 import { getOrCreateAttribute } from "./models";
 import { toBigDecimal } from "./number";
-
 
 const ATTRIBUTE_PERCENTAGE_THRESHOLDS = new TypedMap<string, number>();
 ATTRIBUTE_PERCENTAGE_THRESHOLDS.set(SMOL_BODIES_ADDRESS.toHexString(), 6_200);
@@ -28,7 +27,7 @@ const shouldUpdateAttributePercentages = (collection: Collection): boolean => {
 
 export function updateAttributePercentages(collection: Collection): void {
   if (!shouldUpdateAttributePercentages(collection)) {
-    log.debug("Skipping attribute percentages update for collection: {}", [collection.id]);
+    log.debug("[metadata] Skipping attribute percentages update for collection: {}", [collection.id]);
     return;
   }
 
@@ -37,12 +36,12 @@ export function updateAttributePercentages(collection: Collection): void {
   for (let i = 0; i < totalAttributes; i++) {
     const attribute = Attribute.load(attributeIds[i]);
     if (!attribute) {
-      log.warning("Unknown attribute in collection: {}", [attributeIds[i]]);
+      log.warning("[metadata] Unknown attribute in collection: {}", [attributeIds[i]]);
       continue;
     }
 
     if (["IQ", "Head Size"].includes(attribute.name)) {
-      log.debug("Skipping attribute percentages update for attribute: {}", [attribute.id])
+      log.debug("[metadata] Skipping attribute percentages update for attribute: {}", [attribute.id])
       continue;
     }
 
@@ -58,14 +57,14 @@ export function updateTokenMetadata(token: Token, data: JSON): void {
   const collection = Collection.load(token.collection);
 
   if (!collection) {
-    log.error("Token missing collection: {}, {}", [token.id, token.collection]);
+    log.error("[metadata] Token missing collection: {}, {}", [token.id, token.collection]);
     return;
   }
 
   // Parse metadata
   const name = getJsonStringValue(data, "name");
   if (!name) {
-    log.error("Token metadata missing name: {}", [token.id]);
+    log.error("[metadata] Token metadata missing name: {}", [token.id]);
     return;
   }
 
@@ -88,16 +87,14 @@ export function updateTokenMetadata(token: Token, data: JSON): void {
     let attributes: Attribute[] = [];
     for (let i = 0; i < attributesDataArr.length; i++) {
       const attributeObj = attributesDataArr[i].toObject();
-      const nameData = attributeObj.get("trait_type");
-      const valueData = attributeObj.get("value");
-      if (!nameData || !valueData) {
-        log.error("Attribute missing data for token: {}", [token.id]);
+      const name = getJsonStringValue(attributeObj, "trait_type");
+      const value = getJsonStringValue(attributeObj, "value");
+      if (!name || !value) {
+        log.error("[metadata] Attribute missing data for token: {}", [token.id]);
         continue;
       }
 
-      const name = nameData.toString();
-      const value = valueData.kind === JSONValueKind.NUMBER ? valueData.toI64().toString() : valueData.toString();
-      attributes.push(getOrCreateAttribute(collection, token, name, value));
+      attributes.push(getOrCreateAttribute(collection, token, name as string, value as string));
     }
     
     token.attributes = attributes.map<string>((attribute) => attribute.id);

--- a/subgraphs/smolverse/src/mappings/common.ts
+++ b/subgraphs/smolverse/src/mappings/common.ts
@@ -36,6 +36,7 @@ export function handleTransfer(
       if (landMetadata) {
         token.description = landMetadata.description;
         token.image = landMetadata.image;
+        token.video = landMetadata.video;
         token.attributes = landMetadata.attributes;
       } else {
         tokenUri = `${SMOL_BRAINS_LAND_BASE_URI}0`;
@@ -63,6 +64,7 @@ export function handleTransfer(
         landMetadata = new _LandMetadata("all");
         landMetadata.description = token.description;
         landMetadata.image = token.image;
+        landMetadata.video = token.video;
         landMetadata.attributes = token.attributes;
         landMetadata.save();
       }

--- a/subgraphs/smolverse/src/mappings/randomizer.ts
+++ b/subgraphs/smolverse/src/mappings/randomizer.ts
@@ -37,20 +37,17 @@ export function handleRandomSeeded(event: RandomSeeded): void {
       continue;
     }
 
+    // Shared randomizer, claim ID may not associated
     const claimId = random._claimId;
-    if (!claimId) {
-      log.error("[randomizer] Unknown claim ID for random: {}", [randomId]);
-      continue;
+    if (claimId) {
+      const claim = Claim.load(claimId as string);
+      if (claim) {
+        claim.status = "Revealable";
+        claim.save();
+      } else {
+        log.error("[randomizer] Unknown claim: {}", [claimId as string]);
+      }
     }
-
-    const claim = Claim.load(claimId as string);
-    if (!claim) {
-      log.error("[randomizer] Unknown claim: {}", [claimId as string]);
-      continue;
-    }
-
-    claim.status = "Revealable";
-    claim.save();
 
     store.remove("Random", randomId);
   }

--- a/subgraphs/smolverse/src/mappings/smol-brains-school.ts
+++ b/subgraphs/smolverse/src/mappings/smol-brains-school.ts
@@ -43,10 +43,10 @@ export function handleDropSchool(event: DropSchool): void {
 
     // Update Head Size attribute
     const level = Math.min(
-      parseInt(
+      Math.floor(
         weiToEther(
           BigInt.fromString(iqAttribute.value).div(BigInt.fromI32(50))
-        ).toString()
+        )
       ),
       5
     );

--- a/subgraphs/smolverse/template.yaml
+++ b/subgraphs/smolverse/template.yaml
@@ -10,7 +10,7 @@ dataSources:
     source:
       address: "{{ randomizer_address }}"
       abi: Randomizer
-      startBlock: {{ randomizer_start_block }}
+      startBlock: {{ randomizer_smol_farm_start_block }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/subgraphs/smolverse/template.yaml
+++ b/subgraphs/smolverse/template.yaml
@@ -168,6 +168,8 @@ dataSources:
       abis:
         - name: School
           file: {{{ abis }}}/SmolBrainsSchool.json
+        - name: SmolBrains
+          file: {{{ abis }}}/SmolBrains.json
       eventHandlers:
         - event: DropSchool(uint256)
           handler: handleDropSchool

--- a/subgraphs/smolverse/tests/helpers/metadata.test.ts
+++ b/subgraphs/smolverse/tests/helpers/metadata.test.ts
@@ -19,7 +19,8 @@ const mockTokenData = json.fromBytes(
     {
       "name": "#1",
       "description": "Smol Bodies",
-      "image": "https://gateway.pinata.cloud/ipfs/QmSqwxNFMeFtgdCnjBTTixx46Wi6TH9FtQ5jAp98JnAoeR/1/0.png",
+      "image": "test-image",
+      "video": "test-video",
       "attributes": [
         {
           "trait_type": "Gender",
@@ -52,7 +53,8 @@ test("token attributes are set", () => {
   // Assert token metadata was saved
   assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "name", "Smol Bodies #1");
   assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "description", "Smol Bodies");
-  assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "image", "https://gateway.pinata.cloud/ipfs/QmSqwxNFMeFtgdCnjBTTixx46Wi6TH9FtQ5jAp98JnAoeR/1/0.png");
+  assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "image", "test-image");
+  assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "video", "test-video");
 
   // Assert related attributes were created
   const attributeId1 = `${address}-gender-male`;


### PR DESCRIPTION
- Fixes head size attribute calculation
- Fixes "ABI missing" sync error for `SmolBrains` contract binding
- Updates Randomizer start block so the syncing doesn't start unnecessarily early
- Adds retry mechanism for IPFS fetching
- Adds support for `video` field on `Token` entities to support Smol Brains Land metadata
- Cleans up logs

I deployed the priority items (first two) manually already.

The IPFS retry hasn't gone up yet, so I'm not sure if it will really do anything. I also tried running The Graph's IPFS pinning service on all of the tokenIds, but it didn't seem to do anything either - still getting some IPFS failures during syncing. Not sure how Pinata works, but maybe we can adjust some settings there to pin to The Graph's endpoint as well: https://thegraph.com/docs/en/developer/create-subgraph-hosted#ipfs-on-ethereum-contracts