### PR TITLE
add cron job to handle failed IPFS pulls every hour

### DIFF
--- a/subgraphs/smolverse/schema.graphql
+++ b/subgraphs/smolverse/schema.graphql
@@ -27,6 +27,10 @@ type Collection @entity {
   "Internal for tracking attributes for a collection"
   _attributeIds: [String!]!
 
+  "Internal for tracking token IDs with missing metadata"
+  _missingMetadataTokens: [Token!]!
+  _missingMetadataLastUpdated: BigInt!
+
   name: String!
   standard: TokenStandard
   baseUri: String

--- a/subgraphs/smolverse/src/helpers/constants.ts
+++ b/subgraphs/smolverse/src/helpers/constants.ts
@@ -6,6 +6,9 @@ export const SMOL_BRAINS_PETS_COLLECTION_NAME = "Smol Brains Pets";
 export const SMOL_BODIES_PETS_COLLECTION_NAME = "Smol Bodies Pets";
 export const SMOL_TREASURES_COLLECTION_NAME = "Smol Treasures";
 
+// Cron jobs
+export const MISSING_METADATA_UPDATE_INTERVAL = 3600;
+
 // IPFS
 export const SMOL_BODIES_BASE_URI =
   "https://treasure-marketplace.mypinata.cloud/ipfs/Qmbt6W9QB74VZzJfWbqG7vi2hiE2K4AnoyvWGFDHEjgoqN/";

--- a/subgraphs/smolverse/src/helpers/models.ts
+++ b/subgraphs/smolverse/src/helpers/models.ts
@@ -79,6 +79,7 @@ export function getOrCreateCollection(address: Address): Collection {
     collection.name = getNameForCollection(address);
     collection.standard = TOKEN_STANDARD_ERC721;
     collection._attributeIds = [];
+    collection._missingMetadataTokens = [];
     collection.save();
   }
 

--- a/subgraphs/smolverse/src/mappings/common.ts
+++ b/subgraphs/smolverse/src/mappings/common.ts
@@ -1,21 +1,14 @@
 import { Address, BigInt, log, store } from "@graphprotocol/graph-ts";
 
 import {
-  SMOL_BODIES_PETS_ADDRESS,
-  SMOL_BRAINS_LAND_ADDRESS,
-  SMOL_BRAINS_PETS_ADDRESS,
-} from "@treasure/constants";
-
-import {
   Collection,
   StakedToken,
   Token,
   _LandMetadata,
 } from "../../generated/schema";
-import { SMOL_BRAINS_LAND_BASE_URI } from "../helpers/constants";
-import { getCollectionId, getStakedTokenId } from "../helpers/ids";
-import { getIpfsJson } from "../helpers/json";
-import { updateTokenMetadata } from "../helpers/metadata";
+import { MISSING_METADATA_UPDATE_INTERVAL } from "../helpers/constants";
+import { getStakedTokenId } from "../helpers/ids";
+import { fetchTokenMetadata } from "../helpers/metadata";
 import {
   getOrCreateCollection,
   getOrCreateToken,
@@ -24,6 +17,7 @@ import {
 import { isMint } from "../helpers/utils";
 
 export function handleTransfer(
+  timestamp: BigInt,
   collection: Collection,
   from: Address,
   to: Address,
@@ -34,52 +28,34 @@ export function handleTransfer(
   token.owner = owner.id;
 
   if (isMint(from)) {
-    const tokenIdString = tokenId.toString();
-    token.name = `${collection.name} #${tokenIdString}`;
+    fetchTokenMetadata(collection, token);
+  }
 
-    let landMetadata: _LandMetadata | null = null;
-    let tokenUri: string | null = null;
-    const isLand = collection.id == getCollectionId(SMOL_BRAINS_LAND_ADDRESS);
-    if (isLand) {
-      // Check for cached Land metadata
-      landMetadata = _LandMetadata.load("all");
-      if (landMetadata) {
-        token.description = landMetadata.description;
-        token.image = landMetadata.image;
-        token.video = landMetadata.video;
-        token.attributes = landMetadata.attributes;
-      } else {
-        tokenUri = `${SMOL_BRAINS_LAND_BASE_URI}0`;
-      }
-    } else if (collection.baseUri && collection.baseUri != "test") {
-      // TODO: remove hack when Matchstick supports ipfs
-      const baseUri = collection.baseUri as string;
-      if (
-        collection.id == getCollectionId(SMOL_BRAINS_PETS_ADDRESS) ||
-        collection.id == getCollectionId(SMOL_BODIES_PETS_ADDRESS)
-      ) {
-        tokenUri = `${baseUri}${tokenIdString}.json`;
-      } else {
-        tokenUri = `${baseUri}${tokenIdString}/0`;
+  // Should we run missing metadata cron job?
+  if (
+    timestamp.gt(
+      collection._missingMetadataLastUpdated.plus(
+        BigInt.fromI32(MISSING_METADATA_UPDATE_INTERVAL)
+      )
+    )
+  ) {
+    const tokenIds = collection._missingMetadataTokens;
+    log.debug("Re-fetching missing metadata from {} tokens", [
+      tokenIds.length.toString(),
+    ]);
+
+    // Reset list of missing metadata before we attempt to re-fetch them
+    collection._missingMetadataTokens = [];
+    for (let i = 0; i < tokenIds.length; i++) {
+      const token = Token.load(tokenIds[i]);
+      if (token) {
+        fetchTokenMetadata(collection, token);
       }
     }
 
-    if (tokenUri) {
-      const data = getIpfsJson(tokenUri);
-      if (data) {
-        updateTokenMetadata(token, data);
-      }
-
-      // Cache Land metadata
-      if (isLand && !landMetadata) {
-        landMetadata = new _LandMetadata("all");
-        landMetadata.description = token.description;
-        landMetadata.image = token.image;
-        landMetadata.video = token.video;
-        landMetadata.attributes = token.attributes;
-        landMetadata.save();
-      }
-    }
+    // Update cron job's last run time
+    collection._missingMetadataLastUpdated = timestamp;
+    collection.save();
   }
 
   token.save();

--- a/subgraphs/smolverse/src/mappings/smol-bodies.ts
+++ b/subgraphs/smolverse/src/mappings/smol-bodies.ts
@@ -29,6 +29,7 @@ export function handleTransfer(event: Transfer): void {
   }
 
   const token = commonHandleTransfer(
+    event.block.timestamp,
     collection,
     params.from,
     params.to,

--- a/subgraphs/smolverse/src/mappings/smol-brains-land.ts
+++ b/subgraphs/smolverse/src/mappings/smol-brains-land.ts
@@ -13,5 +13,11 @@ export function handleTransfer(event: Transfer): void {
     collection.save();
   }
 
-  commonHandleTransfer(collection, params.from, params.to, params.tokenId);
+  commonHandleTransfer(
+    event.block.timestamp,
+    collection,
+    params.from,
+    params.to,
+    params.tokenId
+  );
 }

--- a/subgraphs/smolverse/src/mappings/smol-brains.ts
+++ b/subgraphs/smolverse/src/mappings/smol-brains.ts
@@ -19,6 +19,7 @@ export function handleTransfer(event: Transfer): void {
   }
 
   const token = commonHandleTransfer(
+    event.block.timestamp,
     collection,
     params.from,
     params.to,

--- a/subgraphs/smolverse/src/mappings/smol-pets.ts
+++ b/subgraphs/smolverse/src/mappings/smol-pets.ts
@@ -37,5 +37,11 @@ export function handleTransfer(event: Transfer): void {
     collection.save();
   }
 
-  commonHandleTransfer(collection, params.from, params.to, params.tokenId);
+  commonHandleTransfer(
+    event.block.timestamp,
+    collection,
+    params.from,
+    params.to,
+    params.tokenId
+  );
 }

--- a/subgraphs/smolverse/tests/helpers/metadata.test.ts
+++ b/subgraphs/smolverse/tests/helpers/metadata.test.ts
@@ -10,7 +10,7 @@ import {
 
 import { SMOL_BODIES_ADDRESS } from "@treasure/constants";
 
-import { Attribute, Token } from "../../generated/schema";
+import { Attribute, Collection, Token } from "../../generated/schema";
 import { updateTokenMetadata } from "../../src/helpers/metadata";
 import { handleTransfer } from "../../src/mappings/smol-bodies";
 import { createTransferEvent } from "../smol-bodies/utils";
@@ -65,8 +65,9 @@ test("token attributes are set", () => {
   handleTransfer(transferEvent);
 
   const id = `${address}-0x1`;
+  const collection = Collection.load(address) as Collection;
   const token = Token.load(id) as Token;
-  updateTokenMetadata(token, mockTokenData);
+  updateTokenMetadata(collection, token, mockTokenData);
 
   // Assert token metadata was saved
   assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "name", "Smol Bodies #1");
@@ -132,11 +133,13 @@ test("token attribute percentages are set", () => {
   transferEvent3.address = Address.zero();
   handleTransfer(transferEvent3);
 
+  const collection = Collection.load(address) as Collection;
   const token1 = Token.load(`${address}-0x1`) as Token;
   const token2 = Token.load(`${address}-0x2`) as Token;
   const token3 = Token.load(`${address}-0x3`) as Token;
 
   updateTokenMetadata(
+    collection,
     token1,
     json
       .fromBytes(
@@ -162,6 +165,7 @@ test("token attribute percentages are set", () => {
   );
 
   updateTokenMetadata(
+    collection,
     token2,
     json
       .fromBytes(
@@ -187,6 +191,7 @@ test("token attribute percentages are set", () => {
   );
 
   updateTokenMetadata(
+    collection,
     token3,
     json
       .fromBytes(
@@ -254,10 +259,13 @@ test("token attribute percentages are not set until threshold is met", () => {
   );
   handleTransfer(transferEvent);
 
+  const collection = Collection.load(
+    transferEvent.address.toHexString()
+  ) as Collection;
   const token = Token.load(
     `${transferEvent.address.toHexString()}-0x1`
   ) as Token;
-  updateTokenMetadata(token, mockTokenData);
+  updateTokenMetadata(collection, token, mockTokenData);
 
   // Assert attribute percentages were not updated
   const attribute = Attribute.load(


### PR DESCRIPTION
Closes #81 

Adds a cron job run on at least a one-hour interval on token transfer to check for any tokens that are missing metadata due to an `ipfs.cat` error and retries them.