### PR TITLE
add matstick.yaml config for latest framework version

### DIFF
--- a/subgraphs/bridgeworld-stats/matchstick.yaml
+++ b/subgraphs/bridgeworld-stats/matchstick.yaml
@@ -1,0 +1,1 @@
+libsFolder: ../../node_modules/

--- a/subgraphs/bridgeworld-stats/package.json
+++ b/subgraphs/bridgeworld-stats/package.json
@@ -16,7 +16,7 @@
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "graph test -- --lib=../../node_modules/",
+    "test": "graph test",
     "test:arbitrum-testnet": "yarn test",
     "test:arbitrum": "yarn test",
     "test:mainnet": "true"

--- a/subgraphs/bridgeworld/matchstick.yaml
+++ b/subgraphs/bridgeworld/matchstick.yaml
@@ -1,0 +1,1 @@
+libsFolder: ../../node_modules/

--- a/subgraphs/bridgeworld/package.json
+++ b/subgraphs/bridgeworld/package.json
@@ -17,7 +17,7 @@
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "graph test -- --lib=../../node_modules/",
+    "test": "graph test",
     "test:arbitrum-testnet": "yarn test",
     "test:arbitrum": "yarn test",
     "test:mainnet": "true"

--- a/subgraphs/marketplace/matchstick.yaml
+++ b/subgraphs/marketplace/matchstick.yaml
@@ -1,0 +1,1 @@
+libsFolder: ../../node_modules/

--- a/subgraphs/marketplace/package.json
+++ b/subgraphs/marketplace/package.json
@@ -17,7 +17,7 @@
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "graph test -- --lib=../../node_modules/",
+    "test": "graph test",
     "test:arbitrum-testnet": "yarn test",
     "test:arbitrum": "yarn test",
     "test:mainnet": "true"

--- a/subgraphs/smolverse/matchstick.yaml
+++ b/subgraphs/smolverse/matchstick.yaml
@@ -1,0 +1,1 @@
+libsFolder: ../../node_modules/

--- a/subgraphs/smolverse/package.json
+++ b/subgraphs/smolverse/package.json
@@ -16,7 +16,7 @@
     "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
     "prepare:mainnet": "true",
-    "test": "graph test -- --lib=../../node_modules/",
+    "test": "graph test",
     "test:arbitrum-testnet": "yarn test",
     "test:arbitrum": "yarn test",
     "test:mainnet": "true"


### PR DESCRIPTION
Fixes `graph test` command since the latest version of Matchstick dropped the `--lib` command in favor of a `matchstick.yaml` config file