### PR TITLE
Add Questing stats

### DIFF
--- a/packages/constants/src/index.template.ts
+++ b/packages/constants/src/index.template.ts
@@ -7,6 +7,7 @@ export const CONSUMABLE_ADDRESS = Address.fromString(
 export const CRAFTING_ADDRESS = Address.fromString("{{ crafting_address }}");
 export const EXPLORER = "{{ explorer }}";
 export const LEGION_ADDRESS = Address.fromString("{{ legion_address }}");
+export const QUESTING_ADDRESS = Address.fromString("{{ questing_address }}");
 export const TREASURE_ADDRESS = Address.fromString("{{ treasure_address }}");
 export const SMOL_BODIES_ADDRESS = Address.fromString(
   "{{ smol_bodies_address }}"

--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -28,6 +28,12 @@ enum CraftingDifficulty {
   Extractor
 }
 
+enum QuestingDifficulty {
+  Easy
+  Medium
+  Hard
+}
+
 type User @entity {
   id: ID!
   magicDepositCount: Int!
@@ -41,6 +47,8 @@ type User @entity {
   craftsSucceeded: Int!
   craftsFailed: Int!
   brokenTreasuresCount: Int!
+  questsStarted: Int!
+  questsFinished: Int!
   summonsStarted: Int!
   summonsFinished: Int!
 }
@@ -56,6 +64,11 @@ type Legion @entity {
 type _Craft @entity {
   id: ID!
   difficulty: CraftingDifficulty!
+}
+
+type _Quest @entity {
+  id: ID!
+  difficulty: QuestingDifficulty!
 }
 
 type TreasureStat @entity {
@@ -87,8 +100,21 @@ type LegionStat @entity {
   rarity: LegionRarity!
   name: String!
 
-  summoningStat: SummoningStat
   craftingStat: CraftingStat
+  summoningStat: SummoningStat
+  questingStat: QuestingStat
+
+  "Number of Crafts started by this Legion type"
+  craftsStarted: Int!
+
+  "Number of Crafts finished by this Legion type"
+  craftsFinished: Int!
+
+  "Number of successful Crafts by this Legion type"
+  craftsSucceeded: Int!
+
+  "Number of failed Crafts by this Legion type"
+  craftsFailed: Int!
 
   "$MAGIC spent on Summons by this Legion type"
   summoningMagicSpent: BigInt!
@@ -102,10 +128,11 @@ type LegionStat @entity {
   "Number of Summons that have resulted in the creation of this Legion type"
   summonedCount: Int!
 
-  craftsStarted: Int!
-  craftsFinished: Int!
-  craftsSucceeded: Int!
-  craftsFailed: Int!
+  "Number of Quests started by this Legion type"
+  questsStarted: Int!
+
+  "Number of Crafts finished by this Legion type"
+  questsFinished: Int!
 }
 
 type AtlasMineLockStat @entity {
@@ -205,6 +232,45 @@ type Pilgrimage @entity {
 
   current: Int!
   total: Int!
+}
+
+type QuestingDifficultyStat @entity {
+  id: ID!
+
+  startTimestamp: BigInt
+  endTimestamp: BigInt
+
+  difficulty: QuestingDifficulty!
+  questingStat: QuestingStat!
+
+  questsStarted: Int!
+  questsFinished: Int!
+}
+
+type QuestingStat @entity {
+  id: ID!
+
+  "Internal for tracking active unique addresses"
+  _activeAddresses: [String!]!
+
+  "Internal for tracking all unique addresses"
+  _allAddresses: [String!]!
+
+  startTimestamp: BigInt
+  endTimestamp: BigInt
+  interval: Interval!
+
+  questsStarted: Int!
+  questsFinished: Int!
+
+  "Number of unique addresses actively questing throughout time period"
+  activeAddressesCount: Int!
+
+  "Number of unique addresses that have quested at any point"
+  allAddressesCount: Int!
+
+  difficultyStats: [QuestingDifficulty!]! @derivedFrom(field: "questingStat")
+  legionStats: [LegionStat!]! @derivedFrom(field: "questingStat")
 }
 
 type SummoningStat @entity {

--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -49,6 +49,10 @@ type User @entity {
   brokenTreasuresCount: Int!
   questsStarted: Int!
   questsFinished: Int!
+  questingShardsEarned: Int!
+  questingStarlightEarned: Int!
+  questingUniversalLocksEarned: Int!
+  questingTreasuresEarned: Int!
   summonsStarted: Int!
   summonsFinished: Int!
 }
@@ -82,12 +86,16 @@ type TreasureStat @entity {
   tier: Int!
 
   craftingStat: CraftingStat
+  questingStat: QuestingStat
 
   "Number of this Treasure type used in Crafts"
   craftingUsed: Int!
 
   "Number of this Treasure type broken in Crafts"
   craftingBroken: Int!
+
+  "Number of this Treasure type earned in Quests"
+  questingEarned: Int!
 }
 
 type LegionStat @entity {
@@ -131,8 +139,20 @@ type LegionStat @entity {
   "Number of Quests started by this Legion type"
   questsStarted: Int!
 
-  "Number of Crafts finished by this Legion type"
+  "Number of Quests finished by this Legion type"
   questsFinished: Int!
+
+  "Number of Prism Shards earned by this Legion type while questing"
+  questingShardsEarned: Int!
+
+  "Number of Essences of Starlight earned by this Legion type while questing"
+  questingStarlightEarned: Int!
+
+  "Number of Universal Locks earned by this Legion type while questing"
+  questingUniversalLocksEarned: Int!
+
+  "Number of treasures earned by this Legion type while questing"
+  questingTreasuresEarned: Int!
 }
 
 type AtlasMineLockStat @entity {
@@ -245,6 +265,10 @@ type QuestingDifficultyStat @entity {
 
   questsStarted: Int!
   questsFinished: Int!
+  questingShardsEarned: Int!
+  questingStarlightEarned: Int!
+  questingUniversalLocksEarned: Int!
+  questingTreasuresEarned: Int!
 }
 
 type QuestingStat @entity {
@@ -262,6 +286,10 @@ type QuestingStat @entity {
 
   questsStarted: Int!
   questsFinished: Int!
+  questingShardsEarned: Int!
+  questingStarlightEarned: Int!
+  questingUniversalLocksEarned: Int!
+  questingTreasuresEarned: Int!
 
   "Number of unique addresses actively questing throughout time period"
   activeAddressesCount: Int!
@@ -271,6 +299,7 @@ type QuestingStat @entity {
 
   difficultyStats: [QuestingDifficulty!]! @derivedFrom(field: "questingStat")
   legionStats: [LegionStat!]! @derivedFrom(field: "questingStat")
+  treasureStats: [TreasureStat!]! @derivedFrom(field: "questingStat")
 }
 
 type SummoningStat @entity {

--- a/subgraphs/bridgeworld-stats/src/helpers/constants.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/constants.ts
@@ -16,4 +16,3 @@ export const LEGION_RARITIES = [
 export const QUEST_DIFFICULTIES = ["Easy", "Medium", "Hard"];
 
 export const ONE_WEI = BigDecimal.fromString((1e18).toString());
-export const ZERO_BI = BigInt.fromI32(0);

--- a/subgraphs/bridgeworld-stats/src/helpers/constants.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/constants.ts
@@ -13,5 +13,7 @@ export const LEGION_RARITIES = [
   "None",
 ];
 
+export const QUEST_DIFFICULTIES = ["Easy", "Medium", "Hard"];
+
 export const ONE_WEI = BigDecimal.fromString((1e18).toString());
 export const ZERO_BI = BigInt.fromI32(0);

--- a/subgraphs/bridgeworld-stats/src/helpers/ids.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/ids.ts
@@ -62,5 +62,5 @@ export function getLegionId(tokenId: BigInt): string {
 }
 
 export function getQuestId(tokenId: BigInt): string {
-  return `$${QUESTING_ADDRESS.toHexString()}-${tokenId.toHexString()}`;
+  return `${QUESTING_ADDRESS.toHexString()}-${tokenId.toHexString()}`;
 }

--- a/subgraphs/bridgeworld-stats/src/helpers/ids.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/ids.ts
@@ -1,6 +1,10 @@
 import { BigInt } from "@graphprotocol/graph-ts";
 
-import { CRAFTING_ADDRESS, LEGION_ADDRESS } from "@treasure/constants";
+import {
+  CRAFTING_ADDRESS,
+  LEGION_ADDRESS,
+  QUESTING_ADDRESS,
+} from "@treasure/constants";
 
 import { SECONDS_IN_DAY } from "./date";
 import { toPaddedString } from "./number";
@@ -50,9 +54,13 @@ export function getAllTimeId(): string {
 }
 
 export function getCraftId(tokenId: BigInt): string {
-  return [CRAFTING_ADDRESS.toHexString(), tokenId.toHexString()].join("-");
+  return `${CRAFTING_ADDRESS.toHexString()}-${tokenId.toHexString()}`;
 }
 
 export function getLegionId(tokenId: BigInt): string {
-  return [LEGION_ADDRESS.toHexString(), tokenId.toHexString()].join("-");
+  return `${LEGION_ADDRESS.toHexString()}-${tokenId.toHexString()}`;
+}
+
+export function getQuestId(tokenId: BigInt): string {
+  return `$${QUESTING_ADDRESS.toHexString()}-${tokenId.toHexString()}`;
 }

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Entity } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 import {
   AtlasMineLockStat,
@@ -13,7 +13,7 @@ import {
   TreasureStat,
   User,
 } from "../../generated/schema";
-import { LEGION_GENERATIONS, LEGION_RARITIES, ZERO_BI } from "./constants";
+import { LEGION_GENERATIONS, LEGION_RARITIES } from "./constants";
 import {
   SECONDS_IN_DAY,
   SECONDS_IN_HOUR,
@@ -103,7 +103,7 @@ export function getLegionSummonCost(generation: string): BigInt {
     return etherToWei(300);
   }
 
-  return ZERO_BI;
+  return BigInt.zero();
 }
 
 export function getTimeIntervalAtlasMineStats(

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Entity } from "@graphprotocol/graph-ts";
 
 import {
   AtlasMineLockStat,
@@ -7,6 +7,8 @@ import {
   CraftingStat,
   Legion,
   LegionStat,
+  QuestingDifficultyStat,
+  QuestingStat,
   SummoningStat,
   TreasureStat,
   User,
@@ -307,6 +309,111 @@ export function getOrCreateCraftingDifficultyStat(
   if (!stat) {
     stat = new CraftingDifficultyStat(id);
     stat.craftingStat = craftingStatId;
+    stat.difficulty = difficulty;
+    stat.save();
+  }
+
+  return stat;
+}
+
+export function getTimeIntervalQuestingStats(
+  eventTimestamp: BigInt
+): QuestingStat[] {
+  const timestamp = eventTimestamp.toI64() * 1000;
+  const date = new Date(timestamp);
+  const month = date.getUTCMonth();
+  const year = date.getUTCFullYear();
+
+  // Hourly
+  const hourlyId = getHourlyId(timestamp);
+  const hourlyStat = (QuestingStat.load(hourlyId) ||
+    createQuestingStat(hourlyId)) as QuestingStat;
+  const startOfHour = getStartOfHour(timestamp);
+  hourlyStat.interval = "Hourly";
+  hourlyStat.startTimestamp = BigInt.fromI64(startOfHour);
+  hourlyStat.endTimestamp = BigInt.fromI64(startOfHour + SECONDS_IN_HOUR - 1);
+  hourlyStat.save();
+
+  // Daily
+  const dailyId = getDailyId(timestamp);
+  const dailyStat = (QuestingStat.load(dailyId) ||
+    createQuestingStat(dailyId)) as QuestingStat;
+  const startOfDay = getStartOfDay(timestamp);
+  dailyStat.interval = "Daily";
+  dailyStat.startTimestamp = BigInt.fromI64(startOfDay);
+  dailyStat.endTimestamp = BigInt.fromI64(startOfDay + SECONDS_IN_DAY - 1);
+  dailyStat.save();
+
+  // Weekly
+  const weeklyId = getWeeklyId(timestamp);
+  const weeklyStat = (QuestingStat.load(weeklyId) ||
+    createQuestingStat(weeklyId)) as QuestingStat;
+  const startOfWeek = getStartOfWeek(timestamp);
+  weeklyStat.interval = "Weekly";
+  weeklyStat.startTimestamp = BigInt.fromI64(startOfWeek);
+  weeklyStat.endTimestamp = BigInt.fromI64(
+    startOfWeek + SECONDS_IN_DAY * 7 - 1
+  );
+  weeklyStat.save();
+
+  // Monthly
+  const monthlyId = getMonthlyId(timestamp);
+  const monthlyStat = (QuestingStat.load(monthlyId) ||
+    createQuestingStat(monthlyId)) as QuestingStat;
+  const startOfMonth = getStartOfMonth(timestamp);
+  monthlyStat.interval = "Monthly";
+  monthlyStat.startTimestamp = BigInt.fromI64(startOfMonth);
+  monthlyStat.endTimestamp = BigInt.fromI64(
+    startOfMonth + SECONDS_IN_DAY * getDaysInMonth(month, year) - 1
+  );
+  monthlyStat.save();
+
+  // Yearly
+  const yearlyId = getYearlyId(timestamp);
+  const yearlyStat = (QuestingStat.load(yearlyId) ||
+    createQuestingStat(yearlyId)) as QuestingStat;
+  const startOfYear = getStartOfYear(timestamp);
+  yearlyStat.interval = "Yearly";
+  yearlyStat.startTimestamp = BigInt.fromI64(startOfYear);
+  yearlyStat.endTimestamp = BigInt.fromI64(
+    startOfYear + SECONDS_IN_DAY * getDaysInYear(year) - 1
+  );
+  yearlyStat.save();
+
+  // All-time
+  const allTimeId = getAllTimeId();
+  const allTimeStat = (QuestingStat.load(allTimeId) ||
+    createQuestingStat(allTimeId)) as QuestingStat;
+  allTimeStat.interval = "AllTime";
+  allTimeStat.save();
+
+  return [
+    hourlyStat,
+    dailyStat,
+    weeklyStat,
+    monthlyStat,
+    yearlyStat,
+    allTimeStat,
+  ];
+}
+
+export function createQuestingStat(id: string): QuestingStat {
+  const stat = new QuestingStat(id);
+  stat._activeAddresses = [];
+  stat._allAddresses = [];
+  stat.save();
+  return stat;
+}
+
+export function getOrCreateQuestingDifficultyStat(
+  questingStatId: string,
+  difficulty: string
+): QuestingDifficultyStat {
+  const id = `${questingStatId}-difficulty${difficulty}`;
+  let stat = QuestingDifficultyStat.load(id);
+  if (!stat) {
+    stat = new QuestingDifficultyStat(id);
+    stat.questingStat = questingStatId;
     stat.difficulty = difficulty;
     stat.save();
   }

--- a/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
@@ -74,12 +74,15 @@ function handleCraftingStarted(
     difficultyStat.save();
 
     for (let j = 0; j < treasureIds.length; j++) {
-      const treasureStat = getOrCreateTreasureStat(stat.id, treasureIds[j]);
-      treasureStat.startTimestamp = stat.startTimestamp;
-      treasureStat.endTimestamp = stat.endTimestamp;
-      treasureStat.craftingStat = stat.id;
-      treasureStat.craftingUsed += treasureAmounts[j];
-      treasureStat.save();
+      const treasureId = treasureIds[j];
+      if (treasureId.gt(BigInt.zero())) {
+        const treasureStat = getOrCreateTreasureStat(stat.id, treasureId);
+        treasureStat.startTimestamp = stat.startTimestamp;
+        treasureStat.endTimestamp = stat.endTimestamp;
+        treasureStat.craftingStat = stat.id;
+        treasureStat.craftingUsed += treasureAmounts[j];
+        treasureStat.save();
+      }
     }
 
     stat.save();
@@ -184,15 +187,15 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
     }
 
     for (let j = 0; j < brokenTreasureIds.length; j++) {
-      const treasureStat = getOrCreateTreasureStat(
-        stat.id,
-        brokenTreasureIds[j]
-      );
-      treasureStat.startTimestamp = stat.startTimestamp;
-      treasureStat.endTimestamp = stat.endTimestamp;
-      treasureStat.craftingStat = stat.id;
-      treasureStat.craftingBroken += brokenAmounts[j].toI32();
-      treasureStat.save();
+      const treasureId = brokenTreasureIds[j];
+      if (treasureId.gt(BigInt.zero())) {
+        const treasureStat = getOrCreateTreasureStat(stat.id, treasureId);
+        treasureStat.startTimestamp = stat.startTimestamp;
+        treasureStat.endTimestamp = stat.endTimestamp;
+        treasureStat.craftingStat = stat.id;
+        treasureStat.craftingBroken += brokenAmounts[j].toI32();
+        treasureStat.save();
+      }
     }
   }
 }

--- a/subgraphs/bridgeworld-stats/src/mappings/questing.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/questing.ts
@@ -1,0 +1,151 @@
+import { Address, BigInt, log } from "@graphprotocol/graph-ts";
+
+import { QuestStarted as LegacyQuestStarted } from "../../generated/Questing Legacy/Questing";
+import {
+  QuestFinished,
+  QuestRevealed,
+  QuestStarted,
+} from "../../generated/Questing/Questing";
+import { _Quest } from "../../generated/schema";
+import { QUEST_DIFFICULTIES } from "../helpers/constants";
+import { getQuestId } from "../helpers/ids";
+import {
+  getLegion,
+  getOrCreateLegionStat,
+  getOrCreateQuestingDifficultyStat,
+  getOrCreateUser,
+  getTimeIntervalQuestingStats,
+} from "../helpers/models";
+
+function handleQuestStarted(
+  timestamp: BigInt,
+  userAddress: Address,
+  tokenId: BigInt,
+  difficultyIndex: i32
+): void {
+  const user = getOrCreateUser(userAddress);
+  user.questsStarted += 1;
+  user.save();
+
+  const quest = new _Quest(getQuestId(tokenId));
+  const difficulty = QUEST_DIFFICULTIES[difficultyIndex];
+  quest.difficulty = difficulty;
+  quest.save();
+
+  const legion = getLegion(tokenId);
+  if (!legion) {
+    log.error("Legion not found: {}", [tokenId.toString()]);
+  }
+
+  const stats = getTimeIntervalQuestingStats(timestamp);
+  for (let i = 0; i < stats.length; i++) {
+    const stat = stats[i];
+    stat.questsStarted += 1;
+    if (!stat._activeAddresses.includes(user.id)) {
+      stat._activeAddresses = stat._activeAddresses.concat([user.id]);
+      stat.activeAddressesCount = stat._activeAddresses.length;
+    }
+
+    if (!stat._allAddresses.includes(user.id)) {
+      stat._allAddresses = stat._allAddresses.concat([user.id]);
+      stat.allAddressesCount = stat._allAddresses.length;
+    }
+
+    const difficultyStat = getOrCreateQuestingDifficultyStat(
+      stat.id,
+      difficulty
+    );
+    difficultyStat.startTimestamp = stat.startTimestamp;
+    difficultyStat.endTimestamp = stat.endTimestamp;
+    difficultyStat.questsStarted += 1;
+    difficultyStat.save();
+
+    if (legion) {
+      const legionStat = getOrCreateLegionStat(stat.id, legion);
+      legionStat.startTimestamp = stat.startTimestamp;
+      legionStat.endTimestamp = stat.endTimestamp;
+      legionStat.questingStat = stat.id;
+      legionStat.questsStarted += 1;
+      legionStat.save();
+    }
+
+    stat.save();
+  }
+}
+
+export function handleQuestStartedWithDifficulty(event: QuestStarted): void {
+  const params = event.params;
+  handleQuestStarted(
+    event.block.timestamp,
+    params._owner,
+    params._tokenId,
+    params._difficulty
+  );
+}
+
+export function handleQuestStartedWithoutDifficulty(
+  event: LegacyQuestStarted
+): void {
+  const params = event.params;
+  handleQuestStarted(
+    event.block.timestamp,
+    params._owner,
+    params._tokenId,
+    0 // Easy
+  );
+}
+
+export function handleQuestRevealed(event: QuestRevealed): void {}
+
+export function handleQuestFinished(event: QuestFinished): void {
+  const params = event.params;
+  const tokenId = params._tokenId;
+
+  const user = getOrCreateUser(params._owner);
+  user.questsFinished += 1;
+  user.save();
+  const isUserQuesting = user.questsStarted > user.questsFinished;
+
+  const quest = _Quest.load(getQuestId(tokenId));
+  if (!quest) {
+    log.error("Quest not found: {}", [tokenId.toString()]);
+  }
+
+  const legion = getLegion(tokenId);
+  if (!legion) {
+    log.error("Legion not found: {}", [tokenId.toString()]);
+  }
+
+  const stats = getTimeIntervalQuestingStats(event.block.timestamp);
+  for (let i = 0; i < stats.length; i++) {
+    const stat = stats[i];
+    stat.questsFinished += 1;
+    if (!isUserQuesting) {
+      const addressIndex = stat._activeAddresses.indexOf(user.id);
+      if (addressIndex >= 0) {
+        const addresses = stat._activeAddresses;
+        addresses.splice(addressIndex, 1);
+        stat._activeAddresses = addresses;
+        stat.activeAddressesCount = addresses.length;
+      }
+    }
+    stat.save();
+
+    if (quest) {
+      const difficultyStat = getOrCreateQuestingDifficultyStat(
+        stat.id,
+        quest.difficulty
+      );
+      difficultyStat.questsFinished += 1;
+      difficultyStat.save();
+    }
+
+    if (legion) {
+      const legionStat = getOrCreateLegionStat(stat.id, legion);
+      legionStat.startTimestamp = stat.startTimestamp;
+      legionStat.endTimestamp = stat.endTimestamp;
+      legionStat.questsFinished += 1;
+      legionStat.save();
+    }
+  }
+}

--- a/subgraphs/bridgeworld-stats/src/mappings/questing.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/questing.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, log } from "@graphprotocol/graph-ts";
+import { Address, BigInt, log, store } from "@graphprotocol/graph-ts";
 
 import { QuestStarted as LegacyQuestStarted } from "../../generated/Questing Legacy/Questing";
 import {
@@ -212,5 +212,9 @@ export function handleQuestFinished(event: QuestFinished): void {
       legionStat.questsFinished += 1;
       legionStat.save();
     }
+  }
+
+  if (quest) {
+    store.remove("_Quest", quest.id);
   }
 }

--- a/subgraphs/bridgeworld-stats/template.yaml
+++ b/subgraphs/bridgeworld-stats/template.yaml
@@ -126,6 +126,54 @@ dataSources:
         - event: NoPilgrimagesToFinish(indexed address)
           handler: handleNoPilgrimagesToFinish
       file: ./src/mappings/pilgrimage.ts
+  - name: Questing
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      address: "{{ questing_address }}"
+      abi: Questing
+      startBlock: {{ questing_start_block }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Token
+        - User
+        - UserToken
+      abis:
+        - name: Questing
+          file: ../../node_modules/@treasure/subgraph-abis/src/Questing.json
+      eventHandlers:
+        - event: QuestStarted(indexed address,indexed uint256,indexed uint256,uint256,uint8)
+          handler: handleQuestStartedWithDifficulty
+        - event: QuestRevealed(indexed address,indexed uint256,(uint8,uint8,uint8,uint256))
+          handler: handleQuestRevealed
+        - event: QuestFinished(indexed address,indexed uint256)
+          handler: handleQuestFinished
+      file: ./src/mappings/questing.ts
+  - name: Questing Legacy
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      address: "{{ questing_address }}"
+      abi: Questing
+      startBlock: {{ questing_start_block }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Token
+        - User
+        - UserToken
+      abis:
+        - name: Questing
+          file: ../../node_modules/@treasure/subgraph-abis/src/QuestingLegacy.json
+      eventHandlers:
+        - event: QuestStarted(indexed address,indexed uint256,indexed uint256,uint256)
+          handler: handleQuestStartedWithoutDifficulty
+      file: ./src/mappings/questing.ts
   - name: Summoning
     kind: ethereum/contract
     network: {{ network }}

--- a/subgraphs/bridgeworld-stats/tests/crafting/crafting.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/crafting/crafting.test.ts
@@ -1,8 +1,7 @@
 import { assert, clearStore, test } from "matchstick-as";
 
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 
-import { ZERO_BI } from "../../src/helpers/constants";
 import { etherToWei } from "../../src/helpers/number";
 import {
   handleCraftingFinished,
@@ -483,7 +482,7 @@ test("crafting stats count broken treasures", () => {
     USER_ADDRESS,
     1,
     true,
-    ZERO_BI,
+    BigInt.zero(),
     0,
     [92, 96],
     [2, 1]

--- a/subgraphs/bridgeworld-stats/tests/crafting/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/crafting/utils.ts
@@ -7,7 +7,6 @@ import {
   CraftingRevealed,
   CraftingStarted,
 } from "../../generated/Crafting/Crafting";
-import { ZERO_BI } from "../../src/helpers/constants";
 
 export const createCraftingStartedEvent = (
   timestamp: i32,
@@ -47,7 +46,7 @@ export function createCraftingRevealedEvent(
   user: string,
   tokenId: i32,
   success: boolean = true,
-  magicReturned: BigInt = ZERO_BI,
+  magicReturned: BigInt = BigInt.zero(),
   rewardId: i32 = 1,
   brokenTreasures: i32[] = [],
   brokenAmounts: i32[] = [],

--- a/subgraphs/bridgeworld-stats/tests/questing/questing.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/questing/questing.test.ts
@@ -1,0 +1,316 @@
+import { assert, clearStore, test } from "matchstick-as";
+
+import { Address } from "@graphprotocol/graph-ts";
+
+import { handleLegionCreated } from "../../src/mappings/legion";
+import {
+  handleQuestFinished,
+  handleQuestStartedWithDifficulty,
+} from "../../src/mappings/questing";
+import { createLegionCreatedEvent } from "../legion/utils";
+import {
+  LEGION_STAT_ENTITY_TYPE,
+  QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+  QUESTING_STAT_ENTITY_TYPE,
+  USER_ADDRESS,
+  USER_ENTITY_TYPE,
+} from "../utils";
+import { createQuestFinishedEvent, createQuestStartedEvent } from "./utils";
+
+// Feb 9 22, 7:15
+const timestamp = 1644390900;
+const statIds = [
+  "20220209-0700-hourly",
+  "20220209-daily",
+  "20220206-weekly",
+  "202202-monthly",
+  "2022-yearly",
+  "all-time",
+];
+
+test("questing stats count quests started", () => {
+  clearStore();
+
+  const legionCreatedEvent = createLegionCreatedEvent(1, 0, 4);
+  handleLegionCreated(legionCreatedEvent);
+
+  const questStartedEvent = createQuestStartedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1,
+    0,
+    2
+  );
+  handleQuestStartedWithDifficulty(questStartedEvent);
+
+  // Assert user data is updated
+  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "questsStarted", "1");
+
+  const intervals = [
+    "Hourly",
+    "Daily",
+    "Weekly",
+    "Monthly",
+    "Yearly",
+    "AllTime",
+  ];
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "interval",
+      intervals[i]
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questsStarted",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "activeAddressesCount",
+      "1"
+    );
+
+    // Assert all time intervals for legion type are created
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questsStarted",
+      "1"
+    );
+
+    // Assert all time intervals for difficulty are created
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyHard`,
+      "questsStarted",
+      "1"
+    );
+  }
+
+  // Assert start and end times are correct
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[0],
+    "startTimestamp",
+    "1644390000"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[0],
+    "endTimestamp",
+    "1644393599"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[1],
+    "startTimestamp",
+    "1644364800"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[1],
+    "endTimestamp",
+    "1644451199"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[2],
+    "startTimestamp",
+    "1644105600"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[2],
+    "endTimestamp",
+    "1644710399"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[3],
+    "startTimestamp",
+    "1643673600"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[3],
+    "endTimestamp",
+    "1646092799"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[4],
+    "startTimestamp",
+    "1640995200"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[4],
+    "endTimestamp",
+    "1672531199"
+  );
+
+  // Jan 20 22, 23:15
+  const questStartedEvent2 = createQuestStartedEvent(
+    1642720500,
+    Address.zero().toHexString(),
+    1,
+    0,
+    0
+  );
+  handleQuestStartedWithDifficulty(questStartedEvent2);
+
+  // Assert previous intervals are unaffected
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[0],
+    "questsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[1],
+    "questsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    statIds[2],
+    "questsStarted",
+    "1"
+  );
+
+  // Assert new weekly interval was created
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    "20220116-weekly",
+    "questsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    "20220116-weekly",
+    "activeAddressesCount",
+    "1"
+  );
+
+  // Assert new monthly interval was created
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    "202201-monthly",
+    "questsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    "202201-monthly",
+    "activeAddressesCount",
+    "1"
+  );
+
+  // Assert yearly interval contains both
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    "2022-yearly",
+    "questsStarted",
+    "2"
+  );
+  assert.fieldEquals(
+    QUESTING_STAT_ENTITY_TYPE,
+    "2022-yearly",
+    "activeAddressesCount",
+    "2"
+  );
+});
+
+test("questing stats count quests finished", () => {
+  clearStore();
+
+  const legionCreatedEvent = createLegionCreatedEvent(1, 0, 4);
+  handleLegionCreated(legionCreatedEvent);
+
+  const questStartedEvent = createQuestStartedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1,
+    0,
+    0
+  );
+  handleQuestStartedWithDifficulty(questStartedEvent);
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questsStarted",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "activeAddressesCount",
+      "1"
+    );
+
+    // Assert all time intervals for legion type are created
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questsStarted",
+      "1"
+    );
+
+    // Assert all time intervals for difficulty are created
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questsStarted",
+      "1"
+    );
+  }
+
+  const questFinishedEvent = createQuestFinishedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1
+  );
+  handleQuestFinished(questFinishedEvent);
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questsFinished",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "activeAddressesCount",
+      "0"
+    );
+
+    // Assert all time intervals for legion type are created
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questsFinished",
+      "1"
+    );
+
+    // Assert all time intervals for difficulty are created
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questsFinished",
+      "1"
+    );
+  }
+});

--- a/subgraphs/bridgeworld-stats/tests/questing/questing.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/questing/questing.test.ts
@@ -5,6 +5,7 @@ import { Address } from "@graphprotocol/graph-ts";
 import { handleLegionCreated } from "../../src/mappings/legion";
 import {
   handleQuestFinished,
+  handleQuestRevealed,
   handleQuestStartedWithDifficulty,
 } from "../../src/mappings/questing";
 import { createLegionCreatedEvent } from "../legion/utils";
@@ -12,10 +13,15 @@ import {
   LEGION_STAT_ENTITY_TYPE,
   QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
   QUESTING_STAT_ENTITY_TYPE,
+  TREASURE_STAT_ENTITY_TYPE,
   USER_ADDRESS,
   USER_ENTITY_TYPE,
 } from "../utils";
-import { createQuestFinishedEvent, createQuestStartedEvent } from "./utils";
+import {
+  createQuestFinishedEvent,
+  createQuestRevealedEvent,
+  createQuestStartedEvent,
+} from "./utils";
 
 // Feb 9 22, 7:15
 const timestamp = 1644390900;
@@ -226,6 +232,208 @@ test("questing stats count quests started", () => {
     "activeAddressesCount",
     "2"
   );
+});
+
+test("questing stats count consumables earned", () => {
+  clearStore();
+
+  const legionCreatedEvent = createLegionCreatedEvent(1, 0, 4);
+  handleLegionCreated(legionCreatedEvent);
+
+  const questStartedEvent = createQuestStartedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1,
+    0,
+    0
+  );
+  handleQuestStartedWithDifficulty(questStartedEvent);
+
+  const questRevealedEvent = createQuestRevealedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1,
+    3,
+    3,
+    1,
+    0
+  );
+  handleQuestRevealed(questRevealedEvent);
+
+  // Assert user data is updated
+  assert.fieldEquals(
+    USER_ENTITY_TYPE,
+    USER_ADDRESS,
+    "questingShardsEarned",
+    "3"
+  );
+  assert.fieldEquals(
+    USER_ENTITY_TYPE,
+    USER_ADDRESS,
+    "questingStarlightEarned",
+    "3"
+  );
+  assert.fieldEquals(
+    USER_ENTITY_TYPE,
+    USER_ADDRESS,
+    "questingUniversalLocksEarned",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_ENTITY_TYPE,
+    USER_ADDRESS,
+    "questingTreasuresEarned",
+    "0"
+  );
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questingShardsEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questingStarlightEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questingUniversalLocksEarned",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questingTreasuresEarned",
+      "0"
+    );
+
+    // Assert all time intervals for difficulty are created
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questingShardsEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questingStarlightEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questingUniversalLocksEarned",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questingTreasuresEarned",
+      "0"
+    );
+
+    // Assert all time intervals for legions are created
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questingShardsEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questingStarlightEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questingUniversalLocksEarned",
+      "1"
+    );
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questingTreasuresEarned",
+      "0"
+    );
+  }
+});
+
+test("questing stats count treasures earned", () => {
+  clearStore();
+
+  const legionCreatedEvent = createLegionCreatedEvent(1, 0, 4);
+  handleLegionCreated(legionCreatedEvent);
+
+  const questStartedEvent = createQuestStartedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1,
+    0,
+    0
+  );
+  handleQuestStartedWithDifficulty(questStartedEvent);
+
+  const questRevealedEvent = createQuestRevealedEvent(
+    timestamp,
+    USER_ADDRESS,
+    1,
+    3,
+    3,
+    1,
+    92
+  );
+  handleQuestRevealed(questRevealedEvent);
+
+  // Assert user data is updated
+  assert.fieldEquals(
+    USER_ENTITY_TYPE,
+    USER_ADDRESS,
+    "questingTreasuresEarned",
+    "1"
+  );
+
+  for (let i = 0; i < statIds.length; i++) {
+    // Assert all time intervals are created
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "questingTreasuresEarned",
+      "1"
+    );
+
+    // Assert all time intervals for difficulty are created
+    assert.fieldEquals(
+      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
+      `${statIds[i]}-difficultyEasy`,
+      "questingTreasuresEarned",
+      "1"
+    );
+
+    // Assert all time intervals for legions are created
+    assert.fieldEquals(
+      LEGION_STAT_ENTITY_TYPE,
+      `${statIds[i]}-genesis-common`,
+      "questingTreasuresEarned",
+      "1"
+    );
+
+    // Assert all time intervals for treasures are created
+    assert.fieldEquals(
+      TREASURE_STAT_ENTITY_TYPE,
+      `${statIds[i]}-0x5c`,
+      "questingEarned",
+      "1"
+    );
+  }
 });
 
 test("questing stats count quests finished", () => {

--- a/subgraphs/bridgeworld-stats/tests/questing/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/questing/utils.ts
@@ -1,0 +1,83 @@
+import { newMockEvent } from "matchstick-as/assembly";
+
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
+
+import {
+  QuestFinished,
+  QuestRevealed,
+  QuestStarted,
+} from "../../generated/Questing/Questing";
+
+export const createQuestStartedEvent = (
+  timestamp: i32,
+  user: string,
+  tokenId: i32,
+  requestId: i32,
+  difficulty: i32
+): QuestStarted => {
+  const event = changetype<QuestStarted>(newMockEvent());
+  event.block.timestamp = BigInt.fromI32(timestamp);
+  event.parameters = [
+    new ethereum.EventParam(
+      "_owner",
+      ethereum.Value.fromAddress(Address.fromString(user))
+    ),
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),
+    new ethereum.EventParam("_requestId", ethereum.Value.fromI32(requestId)),
+    new ethereum.EventParam("_finishTime", ethereum.Value.fromI32(0)),
+    new ethereum.EventParam("_difficulty", ethereum.Value.fromI32(difficulty)),
+  ];
+
+  return event;
+};
+
+export const createQuestRevealedEvent = (
+  timestamp: i32,
+  user: string,
+  tokenId: i32,
+  starlights: i32 = 0,
+  crystals: i32 = 0,
+  locks: i32 = 0,
+  treasureId: i32 = 0
+): QuestRevealed => {
+  const event = changetype<QuestRevealed>(newMockEvent());
+  event.block.timestamp = BigInt.fromI32(timestamp);
+  event.parameters = [
+    new ethereum.EventParam(
+      "_owner",
+      ethereum.Value.fromAddress(Address.fromString(user))
+    ),
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),
+    new ethereum.EventParam(
+      "_reward",
+      ethereum.Value.fromTuple(
+        changetype<ethereum.Tuple>([
+          ethereum.Value.fromI32(starlights),
+          ethereum.Value.fromI32(crystals),
+          ethereum.Value.fromI32(locks),
+          ethereum.Value.fromI32(treasureId),
+        ])
+      )
+    ),
+  ];
+
+  return event;
+};
+
+export const createQuestFinishedEvent = (
+  timestamp: i32,
+  user: string,
+  tokenId: i32
+): QuestFinished => {
+  const event = changetype<QuestFinished>(newMockEvent());
+  event.block.timestamp = BigInt.fromI32(timestamp);
+  event.parameters = [
+    new ethereum.EventParam(
+      "_owner",
+      ethereum.Value.fromAddress(Address.fromString(user))
+    ),
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),
+  ];
+
+  return event;
+};

--- a/subgraphs/bridgeworld-stats/tests/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/utils.ts
@@ -2,6 +2,8 @@ export const CRAFTING_STAT_ENTITY_TYPE = "CraftingStat";
 export const CRAFTING_DIFFICULTY_STAT_ENTITY_TYPE = "CraftingDifficultyStat";
 export const LEGION_STAT_ENTITY_TYPE = "LegionStat";
 export const SUMMONING_STAT_ENTITY_TYPE = "SummoningStat";
+export const QUESTING_STAT_ENTITY_TYPE = "QuestingStat";
+export const QUESTING_DIFFICULTY_STAT_ENTITY_TYPE = "QuestingDifficultyStat";
 export const TREASURE_STAT_ENTITY_TYPE = "TreasureStat";
 export const USER_ENTITY_TYPE = "User";
 


### PR DESCRIPTION
Closes #36 

- Adds handlers for questing started, revealed, and finished along with stats for counting earnings per difficulty and legion type
- Fixes crafting stats bug recording treasure ID 0