### PR TITLE
[bridgeworld-stats] filter hourly stats by block number; optimize stats models

### DIFF
--- a/packages/config/src/arbitrum-testnet.json
+++ b/packages/config/src/arbitrum-testnet.json
@@ -64,5 +64,7 @@
 
   "treasure_marketplace_buyer_address": "0x24b7377Bf073E54eC42ec6CC8F4CDA6e3deB32A8",
   "treasure_marketplace_address": "0x2426acC898C5E1241904fCEf6E5643241192272D",
-  "treasure_marketplace_start_block": 9264815
+  "treasure_marketplace_start_block": 9264815,
+
+  "hourly_stat_interval_start_block": 8952193
 }

--- a/packages/config/src/arbitrum.json
+++ b/packages/config/src/arbitrum.json
@@ -64,5 +64,7 @@
 
   "treasure_marketplace_buyer_address": "0x812cda2181ed7c45a35a691e0c85e231d218e273",
   "treasure_marketplace_address": "0x2E3b85F85628301a0Bce300Dee3A6B04195A15Ee",
-  "treasure_marketplace_start_block": 2983469
+  "treasure_marketplace_start_block": 2983469,
+
+  "hourly_stat_interval_start_block": 6470000
 }

--- a/packages/constants/src/index.template.ts
+++ b/packages/constants/src/index.template.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 export const BURNER_ADDRESS = Address.fromString("{{ burner_address }}");
 export const CONSUMABLE_ADDRESS = Address.fromString(
@@ -33,4 +33,7 @@ export const MARKETPLACE_ADDRESS = Address.fromString(
 );
 export const MARKETPLACE_BUYER_ADDRESS = Address.fromString(
   "{{ treasure_marketplace_buyer_address }}"
+);
+export const HOURLY_STAT_INTERVAL_START_BLOCK = BigInt.fromString(
+  "{{ hourly_stat_interval_start_block }}"
 );

--- a/subgraphs/bridgeworld-stats/src/mappings/atlas-mine.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/atlas-mine.ts
@@ -17,7 +17,7 @@ export function handleDeposit(event: Deposit): void {
   user.magicDeposited = user.magicDeposited.plus(params.amount);
   user.save();
 
-  const stats = getTimeIntervalAtlasMineStats(event.block.timestamp);
+  const stats = getTimeIntervalAtlasMineStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicDepositCount += 1;
@@ -52,7 +52,7 @@ export function handleWithdraw(event: Withdraw): void {
   user.save();
   const isUserStaked = user.magicDeposited.gt(user.magicWithdrawn);
 
-  const stats = getTimeIntervalAtlasMineStats(event.block.timestamp);
+  const stats = getTimeIntervalAtlasMineStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicWithdrawCount += 1;
@@ -78,7 +78,7 @@ export function handleHarvest(event: Harvest): void {
   user.magicHarvested = user.magicHarvested.plus(params.amount);
   user.save();
 
-  const stats = getTimeIntervalAtlasMineStats(event.block.timestamp);
+  const stats = getTimeIntervalAtlasMineStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicHarvestCount += 1;

--- a/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
@@ -38,7 +38,7 @@ function handleCraftingStarted(
 
   const legion = getLegion(tokenId);
   if (!legion) {
-    log.error("Legion not found: {}", [tokenId.toString()]);
+    log.error("[crafting] Legion not found: {}", [tokenId.toString()]);
   }
 
   const stats = getTimeIntervalCraftingStats(block);
@@ -138,12 +138,12 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
 
   const legion = getLegion(tokenId);
   if (!legion) {
-    log.error("Legion not found: {}", [tokenId.toString()]);
+    log.error("[crafting] Legion not found: {}", [tokenId.toString()]);
   }
 
   const craft = _Craft.load(getCraftId(tokenId));
   if (!craft) {
-    log.error("Craft not found: {}", [tokenId.toString()]);
+    log.error("[crafting] Craft not found: {}", [tokenId.toString()]);
   }
 
   const stats = getTimeIntervalCraftingStats(event.block);
@@ -160,8 +160,6 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
 
     if (legion) {
       const legionStat = getOrCreateLegionStat(stat.id, legion);
-      legionStat.startTimestamp = stat.startTimestamp;
-      legionStat.endTimestamp = stat.endTimestamp;
       legionStat.craftsSucceeded += wasSuccessful ? 1 : 0;
       legionStat.craftsFailed += wasSuccessful ? 0 : 1;
       legionStat.save();
@@ -172,8 +170,6 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
         stat.id,
         craft.difficulty
       );
-      difficultyStat.startTimestamp = stat.startTimestamp;
-      difficultyStat.endTimestamp = stat.endTimestamp;
       difficultyStat.magicConsumed = difficultyStat.magicConsumed.plus(
         etherToWei(5).minus(result.magicReturned)
       );
@@ -211,12 +207,12 @@ export function handleCraftingFinished(event: CraftingFinished): void {
 
   const legion = getLegion(tokenId);
   if (!legion) {
-    log.error("Legion not found: {}", [tokenId.toString()]);
+    log.error("[crafting] Legion not found: {}", [tokenId.toString()]);
   }
 
   const craft = _Craft.load(getCraftId(tokenId));
   if (!craft) {
-    log.error("Craft not found: {}", [tokenId.toString()]);
+    log.error("[crafting] Craft not found: {}", [tokenId.toString()]);
   }
 
   const stats = getTimeIntervalCraftingStats(event.block);
@@ -236,8 +232,6 @@ export function handleCraftingFinished(event: CraftingFinished): void {
 
     if (legion) {
       const legionStat = getOrCreateLegionStat(stat.id, legion);
-      legionStat.startTimestamp = stat.startTimestamp;
-      legionStat.endTimestamp = stat.endTimestamp;
       legionStat.craftsFinished += 1;
       legionStat.save();
     }
@@ -247,8 +241,6 @@ export function handleCraftingFinished(event: CraftingFinished): void {
         stat.id,
         craft.difficulty
       );
-      difficultyStat.startTimestamp = stat.startTimestamp;
-      difficultyStat.endTimestamp = stat.endTimestamp;
       difficultyStat.craftsFinished += 1;
       difficultyStat.save();
     }

--- a/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, log, store } from "@graphprotocol/graph-ts";
+import { Address, BigInt, ethereum, log, store } from "@graphprotocol/graph-ts";
 
 import { CraftingStarted as CraftingLegacyStarted } from "../../generated/Crafting Legacy/Crafting";
 import {
@@ -20,7 +20,7 @@ import {
 import { etherToWei } from "../helpers/number";
 
 function handleCraftingStarted(
-  timestamp: BigInt,
+  block: ethereum.Block,
   userAddress: Address,
   tokenId: BigInt,
   treasureIds: BigInt[],
@@ -41,7 +41,7 @@ function handleCraftingStarted(
     log.error("Legion not found: {}", [tokenId.toString()]);
   }
 
-  const stats = getTimeIntervalCraftingStats(timestamp);
+  const stats = getTimeIntervalCraftingStats(block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.craftsStarted += 1;
@@ -94,7 +94,7 @@ export function handleCraftingStartedWithDifficulty(
 ): void {
   const params = event.params;
   handleCraftingStarted(
-    event.block.timestamp,
+    event.block,
     params._owner,
     params._tokenId,
     params._treasureIds,
@@ -108,7 +108,7 @@ export function handleCraftingStartedWithoutDifficulty(
 ): void {
   const params = event.params;
   handleCraftingStarted(
-    event.block.timestamp,
+    event.block,
     params._owner,
     params._tokenId,
     params._treasureIds,
@@ -146,7 +146,7 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
     log.error("Craft not found: {}", [tokenId.toString()]);
   }
 
-  const stats = getTimeIntervalCraftingStats(event.block.timestamp);
+  const stats = getTimeIntervalCraftingStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicConsumed = stat.magicConsumed.plus(
@@ -219,7 +219,7 @@ export function handleCraftingFinished(event: CraftingFinished): void {
     log.error("Craft not found: {}", [tokenId.toString()]);
   }
 
-  const stats = getTimeIntervalCraftingStats(event.block.timestamp);
+  const stats = getTimeIntervalCraftingStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.craftsFinished += 1;

--- a/subgraphs/bridgeworld-stats/src/mappings/questing.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/questing.ts
@@ -103,13 +103,13 @@ export function handleQuestRevealed(event: QuestRevealed): void {
   const shardsEarned = result.crystalShardAmount;
   const starlightEarned = result.starlightAmount;
   const universalLocksEarned = result.universalLockAmount;
-  const earnedTreasure = result.treasureId.gt(BigInt.zero());
+  const treasuresEarned = result.treasureId.gt(BigInt.zero()) ? 1 : 0;
 
   const user = getOrCreateUser(params._owner);
   user.questingShardsEarned += shardsEarned;
   user.questingStarlightEarned += starlightEarned;
   user.questingUniversalLocksEarned += universalLocksEarned;
-  user.questingTreasuresEarned += earnedTreasure ? 1 : 0;
+  user.questingTreasuresEarned += treasuresEarned;
   user.save();
 
   const legion = getLegion(tokenId);
@@ -128,7 +128,7 @@ export function handleQuestRevealed(event: QuestRevealed): void {
     stat.questingShardsEarned += shardsEarned;
     stat.questingStarlightEarned += starlightEarned;
     stat.questingUniversalLocksEarned += universalLocksEarned;
-    stat.questingTreasuresEarned += earnedTreasure ? 1 : 0;
+    stat.questingTreasuresEarned += treasuresEarned;
     stat.save();
 
     if (legion) {
@@ -136,7 +136,7 @@ export function handleQuestRevealed(event: QuestRevealed): void {
       legionStat.questingShardsEarned += shardsEarned;
       legionStat.questingStarlightEarned += starlightEarned;
       legionStat.questingUniversalLocksEarned += universalLocksEarned;
-      legionStat.questingTreasuresEarned += earnedTreasure ? 1 : 0;
+      legionStat.questingTreasuresEarned += treasuresEarned;
       legionStat.save();
     }
 
@@ -148,16 +148,16 @@ export function handleQuestRevealed(event: QuestRevealed): void {
       difficultyStat.questingShardsEarned += shardsEarned;
       difficultyStat.questingStarlightEarned += starlightEarned;
       difficultyStat.questingUniversalLocksEarned += universalLocksEarned;
-      difficultyStat.questingTreasuresEarned += earnedTreasure ? 1 : 0;
+      difficultyStat.questingTreasuresEarned += treasuresEarned;
       difficultyStat.save();
     }
 
-    if (earnedTreasure) {
+    if (treasuresEarned > 0) {
       const treasureStat = getOrCreateTreasureStat(stat.id, result.treasureId);
       treasureStat.startTimestamp = stat.startTimestamp;
       treasureStat.endTimestamp = stat.endTimestamp;
       treasureStat.questingStat = stat.id;
-      treasureStat.questingEarned += 1;
+      treasureStat.questingEarned += treasuresEarned;
       treasureStat.save();
     }
   }
@@ -208,8 +208,6 @@ export function handleQuestFinished(event: QuestFinished): void {
 
     if (legion) {
       const legionStat = getOrCreateLegionStat(stat.id, legion);
-      legionStat.startTimestamp = stat.startTimestamp;
-      legionStat.endTimestamp = stat.endTimestamp;
       legionStat.questsFinished += 1;
       legionStat.save();
     }

--- a/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
@@ -21,7 +21,7 @@ export function handleSummoningStarted(event: SummoningStarted): void {
 
   const legion = getLegion(params._tokenId);
   if (!legion) {
-    log.error("Legion not found: {}", [params._tokenId.toString()]);
+    log.error("[summoning] Legion not found: {}", [params._tokenId.toString()]);
   }
 
   const stats = getTimeIntervalSummoningStats(event.block);
@@ -66,12 +66,16 @@ export function handleSummoningFinished(event: SummoningFinished): void {
 
   const legion = getLegion(params._returnedId);
   if (!legion) {
-    log.error("Legion not found: {}", [params._returnedId.toString()]);
+    log.error("[summoning] Legion not found: {}", [
+      params._returnedId.toString(),
+    ]);
   }
 
   const newLegion = getLegion(params._newTokenId);
   if (!legion) {
-    log.error("Legion not found: {}", [params._newTokenId.toString()]);
+    log.error("[summoning] Legion not found: {}", [
+      params._newTokenId.toString(),
+    ]);
   }
 
   const stats = getTimeIntervalSummoningStats(event.block);
@@ -91,8 +95,6 @@ export function handleSummoningFinished(event: SummoningFinished): void {
 
     if (legion) {
       const legionStat = getOrCreateLegionStat(stat.id, legion);
-      legionStat.startTimestamp = stat.startTimestamp;
-      legionStat.endTimestamp = stat.endTimestamp;
       legionStat.summonsFinished += 1;
       legionStat.save();
     }
@@ -101,6 +103,7 @@ export function handleSummoningFinished(event: SummoningFinished): void {
       const newLegionStat = getOrCreateLegionStat(stat.id, newLegion);
       newLegionStat.startTimestamp = stat.startTimestamp;
       newLegionStat.endTimestamp = stat.endTimestamp;
+      newLegionStat.summoningStat = stat.id;
       newLegionStat.summonedCount += 1;
       newLegionStat.save();
     }

--- a/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/summoning.ts
@@ -24,7 +24,7 @@ export function handleSummoningStarted(event: SummoningStarted): void {
     log.error("Legion not found: {}", [params._tokenId.toString()]);
   }
 
-  const stats = getTimeIntervalSummoningStats(event.block.timestamp);
+  const stats = getTimeIntervalSummoningStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.summonsStarted += 1;
@@ -74,7 +74,7 @@ export function handleSummoningFinished(event: SummoningFinished): void {
     log.error("Legion not found: {}", [params._newTokenId.toString()]);
   }
 
-  const stats = getTimeIntervalSummoningStats(event.block.timestamp);
+  const stats = getTimeIntervalSummoningStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.summonsFinished += 1;

--- a/subgraphs/bridgeworld-stats/tests/atlas-mine/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/atlas-mine/utils.ts
@@ -2,6 +2,8 @@ import { newMockEvent } from "matchstick-as";
 
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
+import { HOURLY_STAT_INTERVAL_START_BLOCK } from "@treasure/constants";
+
 import {
   Deposit,
   Harvest,
@@ -15,6 +17,7 @@ export function createDepositEvent(
   lock: i32
 ): Deposit {
   const event = changetype<Deposit>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -35,6 +38,7 @@ export function createWithdrawEvent(
   amount: i32
 ): Withdraw {
   const event = changetype<Withdraw>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -54,6 +58,7 @@ export function createHarvestEvent(
   amount: i32
 ): Harvest {
   const event = changetype<Harvest>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(

--- a/subgraphs/bridgeworld-stats/tests/crafting/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/crafting/utils.ts
@@ -2,6 +2,8 @@ import { newMockEvent } from "matchstick-as";
 
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
+import { HOURLY_STAT_INTERVAL_START_BLOCK } from "@treasure/constants";
+
 import {
   CraftingFinished,
   CraftingRevealed,
@@ -18,6 +20,7 @@ export const createCraftingStartedEvent = (
   amounts: i32[] = [1]
 ): CraftingStarted => {
   const event = changetype<CraftingStarted>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -53,6 +56,7 @@ export function createCraftingRevealedEvent(
   rewardAmount: i32 = 1
 ): CraftingRevealed {
   const event = changetype<CraftingRevealed>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -84,6 +88,7 @@ export function createCraftingFinishedEvent(
   tokenId: i32
 ): CraftingFinished {
   const event = changetype<CraftingFinished>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(

--- a/subgraphs/bridgeworld-stats/tests/questing/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/questing/utils.ts
@@ -2,6 +2,8 @@ import { newMockEvent } from "matchstick-as/assembly";
 
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
+import { HOURLY_STAT_INTERVAL_START_BLOCK } from "@treasure/constants";
+
 import {
   QuestFinished,
   QuestRevealed,
@@ -16,6 +18,7 @@ export const createQuestStartedEvent = (
   difficulty: i32
 ): QuestStarted => {
   const event = changetype<QuestStarted>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -41,6 +44,7 @@ export const createQuestRevealedEvent = (
   treasureId: i32 = 0
 ): QuestRevealed => {
   const event = changetype<QuestRevealed>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -70,6 +74,7 @@ export const createQuestFinishedEvent = (
   tokenId: i32
 ): QuestFinished => {
   const event = changetype<QuestFinished>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(

--- a/subgraphs/bridgeworld-stats/tests/summoning/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/summoning/utils.ts
@@ -2,6 +2,8 @@ import { newMockEvent } from "matchstick-as";
 
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
+import { HOURLY_STAT_INTERVAL_START_BLOCK } from "@treasure/constants";
+
 import {
   SummoningFinished,
   SummoningStarted,
@@ -13,6 +15,7 @@ export function createSummoningStartedEvent(
   tokenId: i32
 ): SummoningStarted {
   const event = changetype<SummoningStarted>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(
@@ -32,6 +35,7 @@ export function createSummoningFinishedEvent(
   newTokenId: i32
 ): SummoningFinished {
   const event = changetype<SummoningFinished>(newMockEvent());
+  event.block.number = HOURLY_STAT_INTERVAL_START_BLOCK;
   event.block.timestamp = BigInt.fromI32(timestamp);
   event.parameters = [
     new ethereum.EventParam(


### PR DESCRIPTION
Some attempts at speeding up the sync times:

- Updates the hourly stats to only get created if we're syncing past the specific start block number. The Graph doesn't support `Date.now()` so we have to go by block time. Right now this start block is from ~7 days ago. We can periodically update the config when we make changes to the stats
- Reduces the amount of entity save calls in the model stats generator functions