### PR TITLE
update actions jobs to be subgraph-specific

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,82 +7,242 @@ on:
     branches: [master]
 
 jobs:
-  deploy-dev:
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+  changes:
+    name: Detect Changes
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - network: arbitrum-testnet
+    outputs:
+      bridgeworld: ${{ steps.filter.outputs.bridgeworld }}
+      bridgeworld_stats: ${{ steps.filter.outputs.bridgeworld_stats }}
+      marketplace: ${{ steps.filter.outputs.marketplace }}
+      migration: ${{ steps.filter.outputs.migration }}
+      smolverse: ${{ steps.filter.outputs.smolverse }}
+      snapshot: ${{ steps.filter.outputs.snapshot }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Install node
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          bridgeworld:
+            - "packages/**"
+            - "subgraphs/bridgeworld/**"
+          bridgeworld_stats:
+            - "packages/**"
+            - "subgraphs/bridgeworld-stats/**"
+          marketplace:
+            - "packages/**"
+            - "subgraphs/marketplace/**"
+          migration:
+            - "packages/**"
+            - "subgraphs/migration/**"
+          smolverse:
+            - "packages/**"
+            - "subgraphs/smolverse/**"
+          snapshot:
+            - "packages/**"
+            - "subgraphs/snapshot/**"
+
+  bridgeworld:
+    name: Bridgeworld Subgraph
+    if: ${{ needs.changes.outputs.bridgeworld == "true" }}
+    needs: changes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: subgraphs/bridgeworld
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
         uses: actions/setup-node@v1
         with:
           node-version: 14
-      - name: Install
+      - name: Install dependencies
         run: yarn --frozen-lockfile
-      - name: Prepare
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn prepare:$NETWORK
-      - name: Codegen
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn codegen:$NETWORK
+      - name: Prepare for DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn prepare:dev
+      - name: Prepare for PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
       - name: Test
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn test:$NETWORK
-      - name: Build
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn build:$NETWORK
+        run: yarn test
       - name: Authenticate
         env:
           GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
         run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
-      - name: Deploy to ${{ matrix.network }}
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn deploy:$NETWORK
-  deploy-prod:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - name: Deploy to DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn deploy:dev
+      - name: Deploy to PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn deploy:prod
+
+  bridgeworld_stats:
+    name: Bridgeworld Stats Subgraph
+    if: ${{ needs.changes.outputs.bridgeworld_stats == "true" }}
+    needs: changes
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - network: arbitrum
-          - network: mainnet
+    defaults:
+      run:
+        working-directory: subgraphs/bridgeworld-stats
     steps:
-      - uses: actions/checkout@v2
-      - name: Install node
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
         uses: actions/setup-node@v1
         with:
           node-version: 14
-      - name: Install
+      - name: Install dependencies
         run: yarn --frozen-lockfile
-      - name: Prepare
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn prepare:$NETWORK
-      - name: Codegen
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn codegen:$NETWORK
+      - name: Prepare for DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn prepare:dev
+      - name: Prepare for PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
       - name: Test
+        run: yarn test
+      - name: Authenticate
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn test:$NETWORK
-      - name: Build
-        env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn build:$NETWORK
+          GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
+        run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
+      - name: Deploy to PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn deploy:prod
+
+  marketplace:
+    name: Marketplace Subgraph
+    if: ${{ needs.changes.outputs.marketplace == "true" }}
+    needs: changes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: subgraphs/marketplace
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Prepare for DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn prepare:dev
+      - name: Prepare for PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
+      - name: Test
+        run: yarn test
       - name: Authenticate
         env:
           GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
         run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
-      - name: Deploy to ${{ matrix.network }}
+      - name: Deploy to DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn deploy:dev
+      - name: Deploy to PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn deploy:prod
+
+  migration:
+    name: Migration Subgraph
+    if: ${{ needs.changes.outputs.migration == "true" }} && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: changes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: subgraphs/migration
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Prepare for PROD
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
+      - name: Authenticate
         env:
-          NETWORK: ${{ matrix.network }}
-        run: yarn deploy:$NETWORK
+          GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
+        run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
+      - name: Deploy to PROD
+        run: yarn deploy:prod
+
+  smolverse:
+    name: Smolverse Subgraph
+    if: ${{ needs.changes.outputs.smolverse == "true" }}
+    needs: changes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: subgraphs/smolverse
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Prepare for DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn prepare:dev
+      - name: Prepare for PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
+      - name: Test
+        run: yarn test
+      - name: Authenticate
+        env:
+          GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
+        run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
+      - name: Deploy to DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn deploy:dev
+      - name: Deploy to PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn deploy:prod
+
+  snapshot:
+    name: Snapshot Subgraph
+    if: ${{ needs.changes.outputs.snapshot == "true" }} && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: changes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: subgraphs/snapshot
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Prepare for PROD
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
+      - name: Authenticate
+        env:
+          GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
+        run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
+      - name: Deploy to PROD
+        run: yarn deploy:prod

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@trivago/prettier-plugin-sort-imports": "3.2.0",
     "husky": "7.0.4",
     "lint-staged": "12.3.4",
-    "matchstick-as": "0.3.0",
+    "matchstick-as": "0.4.0",
     "mustache": "4.2.0",
     "prettier": "2.5.1",
     "typescript": "4.5.5"

--- a/package.json
+++ b/package.json
@@ -8,22 +8,7 @@
   ],
   "scripts": {
     "format": "prettier --write .",
-    "prepare:git-hooks": "husky install",
-    "build:arbitrum-testnet": "yarn workspaces run build:arbitrum-testnet",
-    "build:arbitrum": "yarn workspaces run build:arbitrum",
-    "build:mainnet": "yarn workspaces run build:mainnet",
-    "codegen:arbitrum-testnet": "yarn workspaces run codegen:arbitrum-testnet",
-    "codegen:arbitrum": "yarn workspaces run codegen:arbitrum",
-    "codegen:mainnet": "yarn workspaces run codegen:mainnet",
-    "deploy:arbitrum-testnet": "yarn workspaces run deploy:arbitrum-testnet",
-    "deploy:arbitrum": "yarn workspaces run deploy:arbitrum",
-    "deploy:mainnet": "yarn workspaces run deploy:mainnet",
-    "prepare:arbitrum-testnet": "yarn workspaces run prepare:arbitrum-testnet",
-    "prepare:arbitrum": "yarn workspaces run prepare:arbitrum",
-    "prepare:mainnet": "yarn workspaces run prepare:mainnet",
-    "test:arbitrum-testnet": "yarn workspaces run test:arbitrum-testnet",
-    "test:arbitrum": "yarn workspaces run test:arbitrum",
-    "test:mainnet": "yarn workspaces run test:mainnet"
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.26.0",

--- a/subgraphs/bridgeworld-stats/package.json
+++ b/subgraphs/bridgeworld-stats/package.json
@@ -4,21 +4,10 @@
   "description": "Subgraph that powers Bridgeworld Statistics",
   "license": "MIT",
   "scripts": {
-    "build:arbitrum-testnet": "graph build",
-    "build:arbitrum": "graph build",
-    "build:mainnet": "true",
-    "codegen:arbitrum-testnet": "graph codegen",
-    "codegen:arbitrum": "graph codegen",
-    "codegen:mainnet": "true",
-    "deploy:arbitrum-testnet": "true",
-    "deploy:arbitrum": "graph deploy --product hosted-service treasureproject/bridgeworld-stats",
-    "deploy:mainnet": "true",
-    "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
-    "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "prepare:mainnet": "true",
-    "test": "graph test",
-    "test:arbitrum-testnet": "yarn test",
-    "test:arbitrum": "yarn test",
-    "test:mainnet": "true"
+    "codegen": "graph codegen",
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/bridgeworld-stats",
+    "prepare:dev": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
+    "prepare:prod": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
+    "test": "graph test"
   }
 }

--- a/subgraphs/bridgeworld/package.json
+++ b/subgraphs/bridgeworld/package.json
@@ -4,22 +4,12 @@
   "description": "Subgraph that powers Bridgeworld",
   "license": "MIT",
   "scripts": {
-    "build:arbitrum-testnet": "graph build",
-    "build:arbitrum": "graph build",
-    "build:mainnet": "true",
-    "codegen:arbitrum-testnet": "graph codegen",
-    "codegen:arbitrum": "graph codegen",
-    "codegen:mainnet": "true",
-    "deploy:arbitrum-testnet": "graph deploy --product hosted-service treasureproject/bridgeworld-dev",
-    "deploy:arbitrum": "graph deploy --product hosted-service treasureproject/bridgeworld",
-    "deploy:mainnet": "true",
+    "codegen": "graph codegen",
+    "deploy:dev": "graph deploy --product hosted-service treasureproject/bridgeworld-dev",
     "deploy:staging": "graph deploy --product hosted-service treasureproject/bridgeworld-next",
-    "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
-    "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "prepare:mainnet": "true",
-    "test": "graph test",
-    "test:arbitrum-testnet": "yarn test",
-    "test:arbitrum": "yarn test",
-    "test:mainnet": "true"
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/bridgeworld",
+    "prepare:dev": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
+    "prepare:prod": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
+    "test": "graph test"
   }
 }

--- a/subgraphs/marketplace/package.json
+++ b/subgraphs/marketplace/package.json
@@ -4,22 +4,12 @@
   "description": "Subgraph that powers the Treasure Marketplace",
   "license": "MIT",
   "scripts": {
-    "build:arbitrum-testnet": "graph build",
-    "build:arbitrum": "graph build",
-    "build:mainnet": "true",
-    "codegen:arbitrum-testnet": "graph codegen",
-    "codegen:arbitrum": "graph codegen",
-    "codegen:mainnet": "true",
-    "deploy:arbitrum-testnet": "graph deploy --product hosted-service treasureproject/marketplace-dev",
-    "deploy:arbitrum": "graph deploy --product hosted-service treasureproject/marketplace",
-    "deploy:mainnet": "true",
+    "codegen": "graph codegen",
+    "deploy:dev": "graph deploy --product hosted-service treasureproject/marketplace-dev",
     "deploy:staging": "graph deploy --product hosted-service treasureproject/marketplace-next",
-    "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
-    "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "prepare:mainnet": "true",
-    "test": "graph test",
-    "test:arbitrum-testnet": "yarn test",
-    "test:arbitrum": "yarn test",
-    "test:mainnet": "true"
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/marketplace",
+    "prepare:dev": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
+    "prepare:prod": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
+    "test": "graph test"
   }
 }

--- a/subgraphs/migration/package.json
+++ b/subgraphs/migration/package.json
@@ -4,21 +4,8 @@
   "description": "Subgraph that powers Bridgeworld",
   "license": "MIT",
   "scripts": {
-    "build:arbitrum-testnet": "true",
-    "build:arbitrum": "true",
-    "build:mainnet": "graph build",
-    "codegen:arbitrum-testnet": "true",
-    "codegen:arbitrum": "true",
-    "codegen:mainnet": "graph codegen",
-    "deploy:arbitrum-testnet": "true",
-    "deploy:arbitrum": "true",
-    "deploy:mainnet": "graph deploy --product hosted-service treasureproject/migration",
-    "prepare:arbitrum-testnet": "true",
-    "prepare:arbitrum": "true",
-    "prepare:mainnet": "mustache ../../node_modules/@treasure/subgraph-config/src/mainnet.json template.yaml > subgraph.yaml",
-    "test": "true",
-    "test:arbitrum-testnet": "true",
-    "test:arbitrum": "true",
-    "test:mainnet": "yarn test"
+    "codegen": "graph codegen",
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/migration",
+    "prepare:prod": "mustache ../../node_modules/@treasure/subgraph-config/src/mainnet.json template.yaml > subgraph.yaml"
   }
 }

--- a/subgraphs/smolverse/package.json
+++ b/subgraphs/smolverse/package.json
@@ -4,21 +4,11 @@
   "description": "Subgraph that powers Smolverse",
   "license": "MIT",
   "scripts": {
-    "build:arbitrum-testnet": "graph build",
-    "build:arbitrum": "graph build",
-    "build:mainnet": "true",
-    "codegen:arbitrum-testnet": "graph codegen",
-    "codegen:arbitrum": "graph codegen",
-    "codegen:mainnet": "true",
-    "deploy:arbitrum-testnet": "graph deploy --product hosted-service treasureproject/smolverse-dev",
-    "deploy:arbitrum": "graph deploy --product hosted-service treasureproject/smolverse",
-    "deploy:mainnet": "true",
-    "prepare:arbitrum-testnet": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
-    "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "prepare:mainnet": "true",
-    "test": "graph test",
-    "test:arbitrum-testnet": "yarn test",
-    "test:arbitrum": "yarn test",
-    "test:mainnet": "true"
+    "codegen": "graph codegen",
+    "deploy:dev": "graph deploy --product hosted-service treasureproject/smolverse-dev",
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/smolverse",
+    "prepare:dev": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
+    "prepare:prod": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
+    "test": "graph test"
   }
 }

--- a/subgraphs/snapshot/package.json
+++ b/subgraphs/snapshot/package.json
@@ -4,21 +4,8 @@
   "description": "Subgraph to snapshot wallets for opportunities",
   "license": "MIT",
   "scripts": {
-    "build:arbitrum-testnet": "true",
-    "build:arbitrum": "graph build",
-    "build:mainnet": "true",
-    "codegen:arbitrum-testnet": "true",
-    "codegen:arbitrum": "graph codegen",
-    "codegen:mainnet": "true",
-    "deploy:arbitrum-testnet": "true",
-    "deploy:arbitrum": "graph deploy --product hosted-service treasureproject/snapshot",
-    "deploy:mainnet": "true",
-    "prepare:arbitrum-testnet": "true",
-    "prepare:arbitrum": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "prepare:mainnet": "true",
-    "test": "true",
-    "test:arbitrum-testnet": "yarn test",
-    "test:arbitrum": "yarn test",
-    "test:mainnet": "true"
+    "codegen": "graph codegen",
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/snapshot",
+    "prepare:prod": "mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,18 +281,18 @@
     "@types/node" "*"
 
 "@types/express-serve-static-core@^4.17.9":
-  version "4.17.27"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz#7a776191e47295d2a05962ecbb3a4ce97e38b401"
-  integrity sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
 
 "@types/lodash@^4.14.159":
-  version "4.14.178"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
-  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+  version "4.14.179"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
+  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
 
 "@types/node@*":
   version "17.0.8"
@@ -300,9 +300,9 @@
   integrity sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==
 
 "@types/node@^12.12.54":
-  version "12.20.41"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.41.tgz#81d7734c5257da9f04354bd9084a6ebbdd5198a5"
-  integrity sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q==
+  version "12.20.46"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.46.tgz#7e49dee4c54fd19584e6a9e0da5f3dc2e9136bc7"
+  integrity sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -783,9 +783,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chokidar@^3.0.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
-  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -1077,9 +1077,9 @@ detect-node@^2.0.4:
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 docker-compose@^0.23.2:
-  version "0.23.14"
-  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.14.tgz#caa991f05ea43ee4e1b8221064d0a9e0016ee1c7"
-  integrity sha512-n4y10yvZEGtwW4EvpDpiWal2elr6D14Bt8oP3nvlLAxryblEVub689lYhpu8lr54OlTiW9X64BH9SLd9AqljNw==
+  version "0.23.17"
+  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.17.tgz#8816bef82562d9417dc8c790aa4871350f93a2ba"
+  integrity sha512-YJV18YoYIcxOdJKeFcCFihE6F4M2NExWM/d4S1ITcS9samHKnNUihz9kjggr0dNtsrbpFNc7/Yzd19DWs+m1xg==
   dependencies:
     yaml "^1.10.2"
 
@@ -1432,9 +1432,9 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
+"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"
@@ -2256,10 +2256,10 @@ mafmt@^7.0.0:
   dependencies:
     multiaddr "^7.3.0"
 
-matchstick-as@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.3.0.tgz#fb23b9bf7c797363a40c23f098d3101831d088dc"
-  integrity sha512-+nxHlchVHzvcJzcNc8WxCV5FpADVqVJwEBuaq3IvZjp29xVoe/RWpodmTvQw+Pk6bRMAPI5grdmTPjR4hGgrcw==
+matchstick-as@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.4.0.tgz#7456c2f20abee6d12366b65f4216385a9ef62a50"
+  integrity sha512-XkWoXQWUg1ms8DaDMkl2M95woGPB89f7aysjwDNst/x+G9FV48dxcAKSwilJ1BVGV3MqU7HfuKGHxegSsuxQxQ==
   dependencies:
     "@graphprotocol/graph-ts" "^0.24.1"
     assemblyscript "^0.19.20"
@@ -3484,9 +3484,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 ws@^7.4.5:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
-  integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
+  integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
Creates subgraph-specific GitHub Actions jobs so a subgraph only gets deployed when its code or the common packages are changed