### PR TITLE
[bridgeworld-stats] refactor user stats to avoid address arrays

### DIFF
--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -34,29 +34,6 @@ enum QuestingDifficulty {
   Hard
 }
 
-type User @entity {
-  id: ID!
-  magicDepositCount: Int!
-  magicWithdrawCount: Int!
-  magicHarvestCount: Int!
-  magicDeposited: BigInt!
-  magicWithdrawn: BigInt!
-  magicHarvested: BigInt!
-  craftsStarted: Int!
-  craftsFinished: Int!
-  craftsSucceeded: Int!
-  craftsFailed: Int!
-  brokenTreasuresCount: Int!
-  questsStarted: Int!
-  questsFinished: Int!
-  questingShardsEarned: Int!
-  questingStarlightEarned: Int!
-  questingUniversalLocksEarned: Int!
-  questingTreasuresEarned: Int!
-  summonsStarted: Int!
-  summonsFinished: Int!
-}
-
 type Legion @entity {
   id: ID!
   tokenId: BigInt!
@@ -155,6 +132,37 @@ type LegionStat @entity {
   questingTreasuresEarned: Int!
 }
 
+type UserStat @entity {
+  id: ID!
+  address: String!
+
+  startTimestamp: BigInt
+  endTimestamp: BigInt
+  interval: Interval!
+
+  magicDepositCount: Int!
+  magicWithdrawCount: Int!
+  magicHarvestCount: Int!
+  magicDeposited: BigInt!
+  magicWithdrawn: BigInt!
+  magicHarvested: BigInt!
+  craftsStarted: Int!
+  craftsFinished: Int!
+  craftsSucceeded: Int!
+  craftsFailed: Int!
+  brokenTreasuresCount: Int!
+  pilgrimagesStarted: Int!
+  pilgrimagesFinished: Int!
+  questsStarted: Int!
+  questsFinished: Int!
+  questingShardsEarned: Int!
+  questingStarlightEarned: Int!
+  questingUniversalLocksEarned: Int!
+  questingTreasuresEarned: Int!
+  summonsStarted: Int!
+  summonsFinished: Int!
+}
+
 type AtlasMineLockStat @entity {
   id: ID!
 
@@ -170,12 +178,6 @@ type AtlasMineLockStat @entity {
 
 type AtlasMineStat @entity {
   id: ID!
-
-  "Internal for tracking active unique addresses"
-  _activeAddresses: [String!]!
-
-  "Internal for tracking all unique addresses"
-  _allAddresses: [String!]!
 
   startTimestamp: BigInt
   endTimestamp: BigInt
@@ -216,12 +218,6 @@ type CraftingDifficultyStat @entity {
 
 type CraftingStat @entity {
   id: ID!
-
-  "Internal for tracking active unique addresses"
-  _activeAddresses: [String!]!
-
-  "Internal for tracking all unique addresses"
-  _allAddresses: [String!]!
 
   startTimestamp: BigInt
   endTimestamp: BigInt
@@ -274,12 +270,6 @@ type QuestingDifficultyStat @entity {
 type QuestingStat @entity {
   id: ID!
 
-  "Internal for tracking active unique addresses"
-  _activeAddresses: [String!]!
-
-  "Internal for tracking all unique addresses"
-  _allAddresses: [String!]!
-
   startTimestamp: BigInt
   endTimestamp: BigInt
   interval: Interval!
@@ -305,12 +295,6 @@ type QuestingStat @entity {
 
 type SummoningStat @entity {
   id: ID!
-
-  "Internal for tracking active unique addresses"
-  _activeAddresses: [String!]!
-
-  "Internal for tracking all unique addresses"
-  _allAddresses: [String!]!
 
   startTimestamp: BigInt
   endTimestamp: BigInt

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -13,7 +13,7 @@ import {
   QuestingStat,
   SummoningStat,
   TreasureStat,
-  User,
+  UserStat,
 } from "../../generated/schema";
 import { LEGION_GENERATIONS, LEGION_RARITIES } from "./constants";
 import {
@@ -38,17 +38,6 @@ import {
 } from "./ids";
 import { etherToWei } from "./number";
 import { getName, getTier } from "./treasure";
-
-export function getOrCreateUser(address: Address): User {
-  const id = address.toHexString();
-  let user = User.load(id);
-  if (!user) {
-    user = new User(id);
-    user.save();
-  }
-
-  return user;
-}
 
 export function getLegion(tokenId: BigInt): Legion | null {
   return Legion.load(getLegionId(tokenId));
@@ -122,7 +111,7 @@ export function getTimeIntervalAtlasMineStats(
     const hourlyId = getHourlyId(timestamp);
     let hourlyStat = AtlasMineStat.load(hourlyId);
     if (!hourlyStat) {
-      hourlyStat = createAtlasMineStat(hourlyId);
+      hourlyStat = new AtlasMineStat(hourlyId);
       const startOfHour = getStartOfHour(timestamp);
       hourlyStat.interval = "Hourly";
       hourlyStat.startTimestamp = BigInt.fromI64(startOfHour);
@@ -139,7 +128,7 @@ export function getTimeIntervalAtlasMineStats(
   const dailyId = getDailyId(timestamp);
   let dailyStat = AtlasMineStat.load(dailyId);
   if (!dailyStat) {
-    dailyStat = createAtlasMineStat(dailyId);
+    dailyStat = new AtlasMineStat(dailyId);
     const startOfDay = getStartOfDay(timestamp);
     dailyStat.interval = "Daily";
     dailyStat.startTimestamp = BigInt.fromI64(startOfDay);
@@ -152,7 +141,7 @@ export function getTimeIntervalAtlasMineStats(
   const weeklyId = getWeeklyId(timestamp);
   let weeklyStat = AtlasMineStat.load(weeklyId);
   if (!weeklyStat) {
-    weeklyStat = createAtlasMineStat(weeklyId);
+    weeklyStat = new AtlasMineStat(weeklyId);
     const startOfWeek = getStartOfWeek(timestamp);
     weeklyStat.interval = "Weekly";
     weeklyStat.startTimestamp = BigInt.fromI64(startOfWeek);
@@ -167,7 +156,7 @@ export function getTimeIntervalAtlasMineStats(
   const monthlyId = getMonthlyId(timestamp);
   let monthlyStat = AtlasMineStat.load(monthlyId);
   if (!monthlyStat) {
-    monthlyStat = createAtlasMineStat(monthlyId);
+    monthlyStat = new AtlasMineStat(monthlyId);
     const startOfMonth = getStartOfMonth(timestamp);
     monthlyStat.interval = "Monthly";
     monthlyStat.startTimestamp = BigInt.fromI64(startOfMonth);
@@ -182,7 +171,7 @@ export function getTimeIntervalAtlasMineStats(
   const yearlyId = getYearlyId(timestamp);
   let yearlyStat = AtlasMineStat.load(yearlyId);
   if (!yearlyStat) {
-    yearlyStat = createAtlasMineStat(yearlyId);
+    yearlyStat = new AtlasMineStat(yearlyId);
     const startOfYear = getStartOfYear(timestamp);
     yearlyStat.interval = "Yearly";
     yearlyStat.startTimestamp = BigInt.fromI64(startOfYear);
@@ -197,7 +186,7 @@ export function getTimeIntervalAtlasMineStats(
   const allTimeId = getAllTimeId();
   let allTimeStat = AtlasMineStat.load(allTimeId);
   if (!allTimeStat) {
-    allTimeStat = createAtlasMineStat(allTimeId);
+    allTimeStat = new AtlasMineStat(allTimeId);
     allTimeStat.interval = "AllTime";
     allTimeStat.save();
   }
@@ -206,22 +195,18 @@ export function getTimeIntervalAtlasMineStats(
   return stats;
 }
 
-export function createAtlasMineStat(id: string): AtlasMineStat {
-  const stat = new AtlasMineStat(id);
-  stat._activeAddresses = [];
-  stat._allAddresses = [];
-  stat.save();
-  return stat;
-}
-
 export function getOrCreateAtlasMineLockStat(
   atlasMineStatId: string,
-  lock: i32
+  lock: i32,
+  startTimeStamp: BigInt | null = null,
+  endTimestamp: BigInt | null = null
 ): AtlasMineLockStat {
   const id = `${atlasMineStatId}-lock${lock}`;
   let lockStat = AtlasMineLockStat.load(id);
   if (!lockStat) {
     lockStat = new AtlasMineLockStat(id);
+    lockStat.startTimestamp = startTimeStamp;
+    lockStat.endTimestamp = endTimestamp;
     lockStat.atlasMineStat = atlasMineStatId;
     lockStat.lock = lock;
     lockStat.save();
@@ -244,7 +229,7 @@ export function getTimeIntervalCraftingStats(
     const hourlyId = getHourlyId(timestamp);
     let hourlyStat = CraftingStat.load(hourlyId);
     if (!hourlyStat) {
-      hourlyStat = createCraftingStat(hourlyId);
+      hourlyStat = new CraftingStat(hourlyId);
       const startOfHour = getStartOfHour(timestamp);
       hourlyStat.interval = "Hourly";
       hourlyStat.startTimestamp = BigInt.fromI64(startOfHour);
@@ -261,7 +246,7 @@ export function getTimeIntervalCraftingStats(
   const dailyId = getDailyId(timestamp);
   let dailyStat = CraftingStat.load(dailyId);
   if (!dailyStat) {
-    dailyStat = createCraftingStat(dailyId);
+    dailyStat = new CraftingStat(dailyId);
     const startOfDay = getStartOfDay(timestamp);
     dailyStat.interval = "Daily";
     dailyStat.startTimestamp = BigInt.fromI64(startOfDay);
@@ -274,7 +259,7 @@ export function getTimeIntervalCraftingStats(
   const weeklyId = getWeeklyId(timestamp);
   let weeklyStat = CraftingStat.load(weeklyId);
   if (!weeklyStat) {
-    weeklyStat = createCraftingStat(weeklyId);
+    weeklyStat = new CraftingStat(weeklyId);
     const startOfWeek = getStartOfWeek(timestamp);
     weeklyStat.interval = "Weekly";
     weeklyStat.startTimestamp = BigInt.fromI64(startOfWeek);
@@ -289,7 +274,7 @@ export function getTimeIntervalCraftingStats(
   const monthlyId = getMonthlyId(timestamp);
   let monthlyStat = CraftingStat.load(monthlyId);
   if (!monthlyStat) {
-    monthlyStat = createCraftingStat(monthlyId);
+    monthlyStat = new CraftingStat(monthlyId);
     const startOfMonth = getStartOfMonth(timestamp);
     monthlyStat.interval = "Monthly";
     monthlyStat.startTimestamp = BigInt.fromI64(startOfMonth);
@@ -304,7 +289,7 @@ export function getTimeIntervalCraftingStats(
   const yearlyId = getYearlyId(timestamp);
   let yearlyStat = CraftingStat.load(yearlyId);
   if (!yearlyStat) {
-    yearlyStat = createCraftingStat(yearlyId);
+    yearlyStat = new CraftingStat(yearlyId);
     const startOfYear = getStartOfYear(timestamp);
     yearlyStat.interval = "Yearly";
     yearlyStat.startTimestamp = BigInt.fromI64(startOfYear);
@@ -319,7 +304,7 @@ export function getTimeIntervalCraftingStats(
   const allTimeId = getAllTimeId();
   let allTimeStat = CraftingStat.load(allTimeId);
   if (!allTimeStat) {
-    allTimeStat = createCraftingStat(allTimeId);
+    allTimeStat = new CraftingStat(allTimeId);
     allTimeStat.interval = "AllTime";
     allTimeStat.save();
   }
@@ -328,22 +313,18 @@ export function getTimeIntervalCraftingStats(
   return stats;
 }
 
-export function createCraftingStat(id: string): CraftingStat {
-  const stat = new CraftingStat(id);
-  stat._activeAddresses = [];
-  stat._allAddresses = [];
-  stat.save();
-  return stat;
-}
-
 export function getOrCreateCraftingDifficultyStat(
   craftingStatId: string,
-  difficulty: string
+  difficulty: string,
+  startTimeStamp: BigInt | null = null,
+  endTimestamp: BigInt | null = null
 ): CraftingDifficultyStat {
   const id = `${craftingStatId}-difficulty${difficulty}`;
   let stat = CraftingDifficultyStat.load(id);
   if (!stat) {
     stat = new CraftingDifficultyStat(id);
+    stat.startTimestamp = startTimeStamp;
+    stat.endTimestamp = endTimestamp;
     stat.craftingStat = craftingStatId;
     stat.difficulty = difficulty;
     stat.save();
@@ -366,7 +347,7 @@ export function getTimeIntervalQuestingStats(
     const hourlyId = getHourlyId(timestamp);
     let hourlyStat = QuestingStat.load(hourlyId);
     if (!hourlyStat) {
-      hourlyStat = createQuestingStat(hourlyId);
+      hourlyStat = new QuestingStat(hourlyId);
       const startOfHour = getStartOfHour(timestamp);
       hourlyStat.interval = "Hourly";
       hourlyStat.startTimestamp = BigInt.fromI64(startOfHour);
@@ -383,7 +364,7 @@ export function getTimeIntervalQuestingStats(
   const dailyId = getDailyId(timestamp);
   let dailyStat = QuestingStat.load(dailyId);
   if (!dailyStat) {
-    dailyStat = createQuestingStat(dailyId);
+    dailyStat = new QuestingStat(dailyId);
     const startOfDay = getStartOfDay(timestamp);
     dailyStat.interval = "Daily";
     dailyStat.startTimestamp = BigInt.fromI64(startOfDay);
@@ -396,7 +377,7 @@ export function getTimeIntervalQuestingStats(
   const weeklyId = getWeeklyId(timestamp);
   let weeklyStat = QuestingStat.load(weeklyId);
   if (!weeklyStat) {
-    weeklyStat = createQuestingStat(weeklyId);
+    weeklyStat = new QuestingStat(weeklyId);
     const startOfWeek = getStartOfWeek(timestamp);
     weeklyStat.interval = "Weekly";
     weeklyStat.startTimestamp = BigInt.fromI64(startOfWeek);
@@ -411,7 +392,7 @@ export function getTimeIntervalQuestingStats(
   const monthlyId = getMonthlyId(timestamp);
   let monthlyStat = QuestingStat.load(monthlyId);
   if (!monthlyStat) {
-    monthlyStat = createQuestingStat(monthlyId);
+    monthlyStat = new QuestingStat(monthlyId);
     const startOfMonth = getStartOfMonth(timestamp);
     monthlyStat.interval = "Monthly";
     monthlyStat.startTimestamp = BigInt.fromI64(startOfMonth);
@@ -426,7 +407,7 @@ export function getTimeIntervalQuestingStats(
   const yearlyId = getYearlyId(timestamp);
   let yearlyStat = QuestingStat.load(yearlyId);
   if (!yearlyStat) {
-    yearlyStat = createQuestingStat(yearlyId);
+    yearlyStat = new QuestingStat(yearlyId);
     const startOfYear = getStartOfYear(timestamp);
     yearlyStat.interval = "Yearly";
     yearlyStat.startTimestamp = BigInt.fromI64(startOfYear);
@@ -441,7 +422,7 @@ export function getTimeIntervalQuestingStats(
   const allTimeId = getAllTimeId();
   let allTimeStat = QuestingStat.load(allTimeId);
   if (!allTimeStat) {
-    allTimeStat = createQuestingStat(allTimeId);
+    allTimeStat = new QuestingStat(allTimeId);
     allTimeStat.interval = "AllTime";
     allTimeStat.save();
   }
@@ -450,22 +431,18 @@ export function getTimeIntervalQuestingStats(
   return stats;
 }
 
-export function createQuestingStat(id: string): QuestingStat {
-  const stat = new QuestingStat(id);
-  stat._activeAddresses = [];
-  stat._allAddresses = [];
-  stat.save();
-  return stat;
-}
-
 export function getOrCreateQuestingDifficultyStat(
   questingStatId: string,
-  difficulty: string
+  difficulty: string,
+  startTimeStamp: BigInt | null = null,
+  endTimestamp: BigInt | null = null
 ): QuestingDifficultyStat {
   const id = `${questingStatId}-difficulty${difficulty}`;
   let stat = QuestingDifficultyStat.load(id);
   if (!stat) {
     stat = new QuestingDifficultyStat(id);
+    stat.startTimestamp = startTimeStamp;
+    stat.endTimestamp = endTimestamp;
     stat.questingStat = questingStatId;
     stat.difficulty = difficulty;
     stat.save();
@@ -488,7 +465,7 @@ export function getTimeIntervalSummoningStats(
     const hourlyId = getHourlyId(timestamp);
     let hourlyStat = SummoningStat.load(hourlyId);
     if (!hourlyStat) {
-      hourlyStat = createSummoningStat(hourlyId);
+      hourlyStat = new SummoningStat(hourlyId);
       const startOfHour = getStartOfHour(timestamp);
       hourlyStat.interval = "Hourly";
       hourlyStat.startTimestamp = BigInt.fromI64(startOfHour);
@@ -505,7 +482,7 @@ export function getTimeIntervalSummoningStats(
   const dailyId = getDailyId(timestamp);
   let dailyStat = SummoningStat.load(dailyId);
   if (!dailyStat) {
-    dailyStat = createSummoningStat(dailyId);
+    dailyStat = new SummoningStat(dailyId);
     const startOfDay = getStartOfDay(timestamp);
     dailyStat.interval = "Daily";
     dailyStat.startTimestamp = BigInt.fromI64(startOfDay);
@@ -518,7 +495,7 @@ export function getTimeIntervalSummoningStats(
   const weeklyId = getWeeklyId(timestamp);
   let weeklyStat = SummoningStat.load(weeklyId);
   if (!weeklyStat) {
-    weeklyStat = createSummoningStat(weeklyId);
+    weeklyStat = new SummoningStat(weeklyId);
     const startOfWeek = getStartOfWeek(timestamp);
     weeklyStat.interval = "Weekly";
     weeklyStat.startTimestamp = BigInt.fromI64(startOfWeek);
@@ -533,7 +510,7 @@ export function getTimeIntervalSummoningStats(
   const monthlyId = getMonthlyId(timestamp);
   let monthlyStat = SummoningStat.load(monthlyId);
   if (!monthlyStat) {
-    monthlyStat = createSummoningStat(monthlyId);
+    monthlyStat = new SummoningStat(monthlyId);
     const startOfMonth = getStartOfMonth(timestamp);
     monthlyStat.interval = "Monthly";
     monthlyStat.startTimestamp = BigInt.fromI64(startOfMonth);
@@ -548,7 +525,7 @@ export function getTimeIntervalSummoningStats(
   const yearlyId = getYearlyId(timestamp);
   let yearlyStat = SummoningStat.load(yearlyId);
   if (!yearlyStat) {
-    yearlyStat = createSummoningStat(yearlyId);
+    yearlyStat = new SummoningStat(yearlyId);
     const startOfYear = getStartOfYear(timestamp);
     yearlyStat.interval = "Yearly";
     yearlyStat.startTimestamp = BigInt.fromI64(startOfYear);
@@ -563,7 +540,7 @@ export function getTimeIntervalSummoningStats(
   const allTimeId = getAllTimeId();
   let allTimeStat = SummoningStat.load(allTimeId);
   if (!allTimeStat) {
-    allTimeStat = createSummoningStat(allTimeId);
+    allTimeStat = new SummoningStat(allTimeId);
     allTimeStat.interval = "AllTime";
     allTimeStat.save();
   }
@@ -572,17 +549,32 @@ export function getTimeIntervalSummoningStats(
   return stats;
 }
 
-export function createSummoningStat(id: string): SummoningStat {
-  const stat = new SummoningStat(id);
-  stat._activeAddresses = [];
-  stat._allAddresses = [];
-  stat.save();
+export function getOrCreateUserStat(
+  statId: string,
+  address: Address,
+  startTimestamp: BigInt | null = null,
+  endTimestamp: BigInt | null = null,
+  interval: string | null = null
+): UserStat {
+  const id = `${statId}-${address.toHexString()}`;
+  let stat = UserStat.load(id);
+  if (!stat) {
+    stat = new UserStat(id);
+    stat.address = address.toHexString();
+    stat.startTimestamp = startTimestamp;
+    stat.endTimestamp = endTimestamp;
+    stat.interval = (interval || "AllTime") as string;
+    stat.save();
+  }
+
   return stat;
 }
 
 export function getOrCreateLegionStat(
   summoningStatId: string,
-  legion: Legion
+  legion: Legion,
+  startTimestamp: BigInt | null = null,
+  endTimestamp: BigInt | null = null
 ): LegionStat {
   const id = `${summoningStatId}-${legion.name
     .toLowerCase()
@@ -591,6 +583,8 @@ export function getOrCreateLegionStat(
   let stat = LegionStat.load(id);
   if (!stat) {
     stat = new LegionStat(id);
+    stat.startTimestamp = startTimestamp;
+    stat.endTimestamp = endTimestamp;
     stat.generation = legion.generation;
     stat.rarity = legion.rarity;
     stat.name = legion.name;
@@ -602,12 +596,16 @@ export function getOrCreateLegionStat(
 
 export function getOrCreateTreasureStat(
   statId: string,
-  tokenId: BigInt
+  tokenId: BigInt,
+  startTimestamp: BigInt | null = null,
+  endTimestamp: BigInt | null = null
 ): TreasureStat {
   const id = `${statId}-${tokenId.toHexString()}`;
   let stat = TreasureStat.load(id);
   if (!stat) {
     stat = new TreasureStat(id);
+    stat.startTimestamp = startTimestamp;
+    stat.endTimestamp = endTimestamp;
     stat.tokenId = tokenId;
     stat.name = getName(tokenId);
     stat.tier = getTier(tokenId);

--- a/subgraphs/bridgeworld-stats/src/mappings/atlas-mine.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/atlas-mine.ts
@@ -5,67 +5,73 @@ import {
 } from "../../generated/Atlas Mine/AtlasMine";
 import {
   getOrCreateAtlasMineLockStat,
-  getOrCreateUser,
+  getOrCreateUserStat,
   getTimeIntervalAtlasMineStats,
 } from "../helpers/models";
 
 export function handleDeposit(event: Deposit): void {
   const params = event.params;
 
-  const user = getOrCreateUser(params.user);
-  user.magicDepositCount += 1;
-  user.magicDeposited = user.magicDeposited.plus(params.amount);
-  user.save();
-
   const stats = getTimeIntervalAtlasMineStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicDepositCount += 1;
     stat.magicDeposited = stat.magicDeposited.plus(params.amount);
-    if (!stat._activeAddresses.includes(user.id)) {
-      stat._activeAddresses = stat._activeAddresses.concat([user.id]);
-      stat.activeAddressesCount = stat._activeAddresses.length;
+
+    const userStat = getOrCreateUserStat(
+      stat.id,
+      params.user,
+      stat.startTimestamp,
+      stat.endTimestamp,
+      stat.interval
+    );
+    userStat.magicDepositCount += 1;
+    userStat.magicDeposited = userStat.magicDeposited.plus(params.amount);
+    userStat.save();
+
+    if (userStat.magicDepositCount == 1) {
+      stat.activeAddressesCount += 1;
+      stat.allAddressesCount += 1;
     }
 
-    if (!stat._allAddresses.includes(user.id)) {
-      stat._allAddresses = stat._allAddresses.concat([user.id]);
-      stat.allAddressesCount = stat._allAddresses.length;
-    }
-
-    stat.save();
-
-    const lockStat = getOrCreateAtlasMineLockStat(stat.id, params.lock);
-    lockStat.startTimestamp = stat.startTimestamp;
-    lockStat.endTimestamp = stat.endTimestamp;
+    const lockStat = getOrCreateAtlasMineLockStat(
+      stat.id,
+      params.lock,
+      stat.startTimestamp,
+      stat.endTimestamp
+    );
     lockStat.magicDepositCount += 1;
     lockStat.magicDeposited = lockStat.magicDeposited.plus(params.amount);
     lockStat.save();
+
+    stat.save();
   }
 }
 
 export function handleWithdraw(event: Withdraw): void {
   const params = event.params;
 
-  const user = getOrCreateUser(params.user);
-  user.magicWithdrawCount += 1;
-  user.magicWithdrawn = user.magicWithdrawn.plus(params.amount);
-  user.save();
-  const isUserStaked = user.magicDeposited.gt(user.magicWithdrawn);
-
   const stats = getTimeIntervalAtlasMineStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicWithdrawCount += 1;
     stat.magicWithdrawn = stat.magicWithdrawn.plus(params.amount);
-    if (!isUserStaked) {
-      const addressIndex = stat._activeAddresses.indexOf(user.id);
-      if (addressIndex >= 0) {
-        const addresses = stat._activeAddresses;
-        addresses.splice(addressIndex, 1);
-        stat._activeAddresses = addresses;
-        stat.activeAddressesCount = addresses.length;
-      }
+
+    const userStat = getOrCreateUserStat(
+      stat.id,
+      params.user,
+      stat.startTimestamp,
+      stat.endTimestamp,
+      stat.interval
+    );
+    userStat.magicWithdrawCount += 1;
+    userStat.magicWithdrawn = userStat.magicWithdrawn.plus(params.amount);
+    userStat.save();
+
+    if (userStat.magicDepositCount == userStat.magicWithdrawCount) {
+      stat.activeAddressesCount -= 1;
     }
+
     stat.save();
   }
 }
@@ -73,16 +79,23 @@ export function handleWithdraw(event: Withdraw): void {
 export function handleHarvest(event: Harvest): void {
   const params = event.params;
 
-  const user = getOrCreateUser(params.user);
-  user.magicHarvestCount += 1;
-  user.magicHarvested = user.magicHarvested.plus(params.amount);
-  user.save();
-
   const stats = getTimeIntervalAtlasMineStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.magicHarvestCount += 1;
     stat.magicHarvested = stat.magicHarvested.plus(params.amount);
+
+    const userStat = getOrCreateUserStat(
+      stat.id,
+      params.user,
+      stat.startTimestamp,
+      stat.endTimestamp,
+      stat.interval
+    );
+    userStat.magicHarvestCount += 1;
+    userStat.magicHarvested = userStat.magicHarvested.plus(params.amount);
+    userStat.save();
+
     stat.save();
   }
 }

--- a/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/crafting.ts
@@ -14,7 +14,7 @@ import {
   getOrCreateCraftingDifficultyStat,
   getOrCreateLegionStat,
   getOrCreateTreasureStat,
-  getOrCreateUser,
+  getOrCreateUserStat,
   getTimeIntervalCraftingStats,
 } from "../helpers/models";
 import { etherToWei } from "../helpers/number";
@@ -27,10 +27,6 @@ function handleCraftingStarted(
   treasureAmounts: i32[],
   difficultyIndex: i32
 ): void {
-  const user = getOrCreateUser(userAddress);
-  user.craftsStarted += 1;
-  user.save();
-
   const craft = new _Craft(getCraftId(tokenId));
   const difficulty = CRAFT_DIFFICULTIES[difficultyIndex];
   craft.difficulty = difficulty;
@@ -45,20 +41,29 @@ function handleCraftingStarted(
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.craftsStarted += 1;
-    if (!stat._activeAddresses.includes(user.id)) {
-      stat._activeAddresses = stat._activeAddresses.concat([user.id]);
-      stat.activeAddressesCount = stat._activeAddresses.length;
-    }
 
-    if (!stat._allAddresses.includes(user.id)) {
-      stat._allAddresses = stat._allAddresses.concat([user.id]);
-      stat.allAddressesCount = stat._allAddresses.length;
+    const userStat = getOrCreateUserStat(
+      stat.id,
+      userAddress,
+      stat.startTimestamp,
+      stat.endTimestamp,
+      stat.interval
+    );
+    userStat.craftsStarted += 1;
+    userStat.save();
+
+    if (userStat.craftsStarted == 1) {
+      stat.activeAddressesCount += 1;
+      stat.allAddressesCount += 1;
     }
 
     if (legion) {
-      const legionStat = getOrCreateLegionStat(stat.id, legion);
-      legionStat.startTimestamp = stat.startTimestamp;
-      legionStat.endTimestamp = stat.endTimestamp;
+      const legionStat = getOrCreateLegionStat(
+        stat.id,
+        legion,
+        stat.startTimestamp,
+        stat.endTimestamp
+      );
       legionStat.craftingStat = stat.id;
       legionStat.craftsStarted += 1;
       legionStat.save();
@@ -66,19 +71,22 @@ function handleCraftingStarted(
 
     const difficultyStat = getOrCreateCraftingDifficultyStat(
       stat.id,
-      difficulty
+      difficulty,
+      stat.startTimestamp,
+      stat.endTimestamp
     );
-    difficultyStat.startTimestamp = stat.startTimestamp;
-    difficultyStat.endTimestamp = stat.endTimestamp;
     difficultyStat.craftsStarted += 1;
     difficultyStat.save();
 
     for (let j = 0; j < treasureIds.length; j++) {
       const treasureId = treasureIds[j];
       if (treasureId.gt(BigInt.zero())) {
-        const treasureStat = getOrCreateTreasureStat(stat.id, treasureId);
-        treasureStat.startTimestamp = stat.startTimestamp;
-        treasureStat.endTimestamp = stat.endTimestamp;
+        const treasureStat = getOrCreateTreasureStat(
+          stat.id,
+          treasureId,
+          stat.startTimestamp,
+          stat.endTimestamp
+        );
         treasureStat.craftingStat = stat.id;
         treasureStat.craftingUsed += treasureAmounts[j];
         treasureStat.save();
@@ -130,12 +138,6 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
     brokenTreasuresCount += brokenAmounts[i].toI32();
   }
 
-  const user = getOrCreateUser(params._owner);
-  user.craftsSucceeded += wasSuccessful ? 1 : 0;
-  user.craftsFailed += wasSuccessful ? 0 : 1;
-  user.brokenTreasuresCount += brokenTreasuresCount;
-  user.save();
-
   const legion = getLegion(tokenId);
   if (!legion) {
     log.error("[crafting] Legion not found: {}", [tokenId.toString()]);
@@ -156,10 +158,27 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
     stat.craftsSucceeded += wasSuccessful ? 1 : 0;
     stat.craftsFailed += wasSuccessful ? 0 : 1;
     stat.brokenTreasuresCount += brokenTreasuresCount;
-    stat.save();
+
+    const userStat = getOrCreateUserStat(
+      stat.id,
+      params._owner,
+      stat.startTimestamp,
+      stat.endTimestamp,
+      stat.interval
+    );
+    userStat.craftsSucceeded += wasSuccessful ? 1 : 0;
+    userStat.craftsFailed += wasSuccessful ? 0 : 1;
+    userStat.brokenTreasuresCount += brokenTreasuresCount;
+    userStat.save();
 
     if (legion) {
-      const legionStat = getOrCreateLegionStat(stat.id, legion);
+      const legionStat = getOrCreateLegionStat(
+        stat.id,
+        legion,
+        stat.startTimestamp,
+        stat.endTimestamp
+      );
+      legionStat.craftingStat = stat.id;
       legionStat.craftsSucceeded += wasSuccessful ? 1 : 0;
       legionStat.craftsFailed += wasSuccessful ? 0 : 1;
       legionStat.save();
@@ -168,7 +187,9 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
     if (craft) {
       const difficultyStat = getOrCreateCraftingDifficultyStat(
         stat.id,
-        craft.difficulty
+        craft.difficulty,
+        stat.startTimestamp,
+        stat.endTimestamp
       );
       difficultyStat.magicConsumed = difficultyStat.magicConsumed.plus(
         etherToWei(5).minus(result.magicReturned)
@@ -185,25 +206,25 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
     for (let j = 0; j < brokenTreasureIds.length; j++) {
       const treasureId = brokenTreasureIds[j];
       if (treasureId.gt(BigInt.zero())) {
-        const treasureStat = getOrCreateTreasureStat(stat.id, treasureId);
-        treasureStat.startTimestamp = stat.startTimestamp;
-        treasureStat.endTimestamp = stat.endTimestamp;
+        const treasureStat = getOrCreateTreasureStat(
+          stat.id,
+          treasureId,
+          stat.startTimestamp,
+          stat.endTimestamp
+        );
         treasureStat.craftingStat = stat.id;
         treasureStat.craftingBroken += brokenAmounts[j].toI32();
         treasureStat.save();
       }
     }
+
+    stat.save();
   }
 }
 
 export function handleCraftingFinished(event: CraftingFinished): void {
   const params = event.params;
   const tokenId = params._tokenId;
-
-  const user = getOrCreateUser(params._owner);
-  user.craftsFinished += 1;
-  user.save();
-  const isUserCrafting = user.craftsStarted > user.craftsFinished;
 
   const legion = getLegion(tokenId);
   if (!legion) {
@@ -219,19 +240,29 @@ export function handleCraftingFinished(event: CraftingFinished): void {
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
     stat.craftsFinished += 1;
-    if (!isUserCrafting) {
-      const addressIndex = stat._activeAddresses.indexOf(user.id);
-      if (addressIndex >= 0) {
-        const addresses = stat._activeAddresses;
-        addresses.splice(addressIndex, 1);
-        stat._activeAddresses = addresses;
-        stat.activeAddressesCount = addresses.length;
-      }
+
+    const userStat = getOrCreateUserStat(
+      stat.id,
+      params._owner,
+      stat.startTimestamp,
+      stat.endTimestamp,
+      stat.interval
+    );
+    userStat.craftsFinished += 1;
+    userStat.save();
+
+    if (userStat.craftsStarted == userStat.craftsFinished) {
+      stat.activeAddressesCount -= 1;
     }
-    stat.save();
 
     if (legion) {
-      const legionStat = getOrCreateLegionStat(stat.id, legion);
+      const legionStat = getOrCreateLegionStat(
+        stat.id,
+        legion,
+        stat.startTimestamp,
+        stat.endTimestamp
+      );
+      legionStat.craftingStat = stat.id;
       legionStat.craftsFinished += 1;
       legionStat.save();
     }
@@ -244,6 +275,8 @@ export function handleCraftingFinished(event: CraftingFinished): void {
       difficultyStat.craftsFinished += 1;
       difficultyStat.save();
     }
+
+    stat.save();
   }
 
   if (craft) {

--- a/subgraphs/bridgeworld-stats/tests/atlas-mine/atlas-mine.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/atlas-mine/atlas-mine.test.ts
@@ -1,21 +1,23 @@
 import { assert, clearStore, test } from "matchstick-as";
 
+import { Address } from "@graphprotocol/graph-ts";
+
 import {
   handleDeposit,
   handleHarvest,
   handleWithdraw,
 } from "../../src/mappings/atlas-mine";
 import {
+  ATLAS_MINE_LOCK_STAT_ENTITY_TYPE,
+  ATLAS_MINE_STAT_ENTITY_TYPE,
+  USER_ADDRESS,
+  USER_STAT_ENTITY_TYPE,
+} from "../utils";
+import {
   createDepositEvent,
   createHarvestEvent,
   createWithdrawEvent,
 } from "./utils";
-
-const ATLAS_MINE_STAT_ENTITY_TYPE = "AtlasMineStat";
-const ATLAS_MIN_LOCK_STAT_ENTITY_TYPE = "AtlasMineLockStat";
-const USER_ENTITY_TYPE = "User";
-const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";
-const USER_ADDRESS2 = "0x461950b159366edcd2bcbee8126d973ac49238e1";
 
 // Feb 9 22, 7:15
 const timestamp = 1644390900;
@@ -78,13 +80,13 @@ test("atlas mine stats count deposits", () => {
 
     // Assert all time intervals for lock period are created
     assert.fieldEquals(
-      ATLAS_MIN_LOCK_STAT_ENTITY_TYPE,
+      ATLAS_MINE_LOCK_STAT_ENTITY_TYPE,
       `${statIds[i]}-lock0`,
       "magicDepositCount",
       "1"
     );
     assert.fieldEquals(
-      ATLAS_MIN_LOCK_STAT_ENTITY_TYPE,
+      ATLAS_MINE_LOCK_STAT_ENTITY_TYPE,
       `${statIds[i]}-lock0`,
       "magicDeposited",
       "500"
@@ -154,7 +156,12 @@ test("atlas mine stats count deposits", () => {
   );
 
   // Jan 20 22, 23:15
-  const depositEvent2 = createDepositEvent(1642720500, USER_ADDRESS2, 100, 1);
+  const depositEvent2 = createDepositEvent(
+    1642720500,
+    Address.zero().toHexString(),
+    100,
+    1
+  );
   handleDeposit(depositEvent2);
 
   // Assert previous intervals are unaffected
@@ -320,10 +327,6 @@ test("atlas mine stats count harvests", () => {
   const harvestEvent = createHarvestEvent(timestamp, USER_ADDRESS, 10);
   handleHarvest(harvestEvent);
 
-  // Assert user was created
-  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "magicHarvestCount", "1");
-  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "magicHarvested", "10");
-
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(
@@ -335,6 +338,20 @@ test("atlas mine stats count harvests", () => {
     assert.fieldEquals(
       ATLAS_MINE_STAT_ENTITY_TYPE,
       statIds[i],
+      "magicHarvested",
+      "10"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "magicHarvestCount",
+      "1"
+    );
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
       "magicHarvested",
       "10"
     );

--- a/subgraphs/bridgeworld-stats/tests/crafting/crafting.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/crafting/crafting.test.ts
@@ -16,7 +16,7 @@ import {
   LEGION_STAT_ENTITY_TYPE,
   TREASURE_STAT_ENTITY_TYPE,
   USER_ADDRESS,
-  USER_ENTITY_TYPE,
+  USER_STAT_ENTITY_TYPE,
 } from "../utils";
 import {
   createCraftingFinishedEvent,
@@ -50,9 +50,6 @@ test("crafting stats count crafts started", () => {
   );
   handleCraftingStartedWithDifficulty(craftingStartedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "craftsStarted", "1");
-
   const intervals = [
     "Hourly",
     "Daily",
@@ -80,6 +77,14 @@ test("crafting stats count crafts started", () => {
       CRAFTING_STAT_ENTITY_TYPE,
       statIds[i],
       "activeAddressesCount",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "craftsStarted",
       "1"
     );
 
@@ -163,17 +168,23 @@ test("crafting stats count crafts started", () => {
   );
 
   // Jan 20 22, 23:15
-  const craftinggStartedEvent2 = createCraftingStartedEvent(
+  const craftingStartedEvent2 = createCraftingStartedEvent(
     1642720500,
     Address.zero().toHexString(),
     1
   );
-  handleCraftingStartedWithDifficulty(craftinggStartedEvent2);
+  handleCraftingStartedWithDifficulty(craftingStartedEvent2);
 
   // Assert previous intervals are unaffected
   assert.fieldEquals(
     CRAFTING_STAT_ENTITY_TYPE,
     statIds[0],
+    "craftsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `${statIds[0]}-${USER_ADDRESS}`,
     "craftsStarted",
     "1"
   );
@@ -184,8 +195,20 @@ test("crafting stats count crafts started", () => {
     "1"
   );
   assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `${statIds[1]}-${USER_ADDRESS}`,
+    "craftsStarted",
+    "1"
+  );
+  assert.fieldEquals(
     CRAFTING_STAT_ENTITY_TYPE,
     statIds[2],
+    "craftsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `${statIds[2]}-${USER_ADDRESS}`,
     "craftsStarted",
     "1"
   );
@@ -203,6 +226,12 @@ test("crafting stats count crafts started", () => {
     "activeAddressesCount",
     "1"
   );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `20220116-weekly-${Address.zero().toHexString()}`,
+    "craftsStarted",
+    "1"
+  );
 
   // Assert new monthly interval was created
   assert.fieldEquals(
@@ -215,6 +244,12 @@ test("crafting stats count crafts started", () => {
     CRAFTING_STAT_ENTITY_TYPE,
     "202201-monthly",
     "activeAddressesCount",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `202201-monthly-${Address.zero().toHexString()}`,
+    "craftsStarted",
     "1"
   );
 
@@ -230,6 +265,18 @@ test("crafting stats count crafts started", () => {
     "2022-yearly",
     "activeAddressesCount",
     "2"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `2022-yearly-${USER_ADDRESS}`,
+    "craftsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `2022-yearly-${Address.zero().toHexString()}`,
+    "craftsStarted",
+    "1"
   );
 });
 
@@ -383,14 +430,19 @@ test("crafting stats count crafts succeeded", () => {
   );
   handleCraftingRevealed(craftingRevealedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "craftsSucceeded", "1");
-
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(
       CRAFTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "craftsSucceeded",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
       "craftsSucceeded",
       "1"
     );
@@ -434,14 +486,19 @@ test("crafting stats count crafts failed", () => {
   );
   handleCraftingRevealed(craftingRevealedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "craftsFailed", "1");
-
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(
       CRAFTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "craftsFailed",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
       "craftsFailed",
       "1"
     );
@@ -489,19 +546,19 @@ test("crafting stats count broken treasures", () => {
   );
   handleCraftingRevealed(craftingRevealedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(
-    USER_ENTITY_TYPE,
-    USER_ADDRESS,
-    "brokenTreasuresCount",
-    "3"
-  );
-
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(
       CRAFTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "brokenTreasuresCount",
+      "3"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
       "brokenTreasuresCount",
       "3"
     );
@@ -543,38 +600,6 @@ test("crafting stats count crafts finished", () => {
   );
   handleCraftingStartedWithDifficulty(craftingStartedEvent);
 
-  for (let i = 0; i < statIds.length; i++) {
-    // Assert all time intervals are created
-    assert.fieldEquals(
-      CRAFTING_STAT_ENTITY_TYPE,
-      statIds[i],
-      "craftsStarted",
-      "1"
-    );
-    assert.fieldEquals(
-      CRAFTING_STAT_ENTITY_TYPE,
-      statIds[i],
-      "activeAddressesCount",
-      "1"
-    );
-
-    // Assert all time intervals for legion type are created
-    assert.fieldEquals(
-      LEGION_STAT_ENTITY_TYPE,
-      `${statIds[i]}-genesis-common`,
-      "craftsStarted",
-      "1"
-    );
-
-    // Assert all time intervals for difficulty are created
-    assert.fieldEquals(
-      CRAFTING_DIFFICULTY_STAT_ENTITY_TYPE,
-      `${statIds[i]}-difficultyPrism`,
-      "craftsStarted",
-      "1"
-    );
-  }
-
   const craftingFinishedEvent = createCraftingFinishedEvent(
     timestamp,
     USER_ADDRESS,
@@ -595,6 +620,20 @@ test("crafting stats count crafts finished", () => {
       statIds[i],
       "activeAddressesCount",
       "0"
+    );
+    assert.fieldEquals(
+      CRAFTING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "allAddressesCount",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "craftsFinished",
+      "1"
     );
 
     // Assert all time intervals for legion type are created

--- a/subgraphs/bridgeworld-stats/tests/questing/questing.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/questing/questing.test.ts
@@ -15,7 +15,7 @@ import {
   QUESTING_STAT_ENTITY_TYPE,
   TREASURE_STAT_ENTITY_TYPE,
   USER_ADDRESS,
-  USER_ENTITY_TYPE,
+  USER_STAT_ENTITY_TYPE,
 } from "../utils";
 import {
   createQuestFinishedEvent,
@@ -49,9 +49,6 @@ test("questing stats count quests started", () => {
   );
   handleQuestStartedWithDifficulty(questStartedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(USER_ENTITY_TYPE, USER_ADDRESS, "questsStarted", "1");
-
   const intervals = [
     "Hourly",
     "Daily",
@@ -78,7 +75,21 @@ test("questing stats count quests started", () => {
     assert.fieldEquals(
       QUESTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "allAddressesCount",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
       "activeAddressesCount",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "questsStarted",
       "1"
     );
 
@@ -260,32 +271,6 @@ test("questing stats count consumables earned", () => {
   );
   handleQuestRevealed(questRevealedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(
-    USER_ENTITY_TYPE,
-    USER_ADDRESS,
-    "questingShardsEarned",
-    "3"
-  );
-  assert.fieldEquals(
-    USER_ENTITY_TYPE,
-    USER_ADDRESS,
-    "questingStarlightEarned",
-    "3"
-  );
-  assert.fieldEquals(
-    USER_ENTITY_TYPE,
-    USER_ADDRESS,
-    "questingUniversalLocksEarned",
-    "1"
-  );
-  assert.fieldEquals(
-    USER_ENTITY_TYPE,
-    USER_ADDRESS,
-    "questingTreasuresEarned",
-    "0"
-  );
-
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(
@@ -309,6 +294,32 @@ test("questing stats count consumables earned", () => {
     assert.fieldEquals(
       QUESTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "questingTreasuresEarned",
+      "0"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "questingShardsEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "questingStarlightEarned",
+      "3"
+    );
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "questingUniversalLocksEarned",
+      "1"
+    );
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
       "questingTreasuresEarned",
       "0"
     );
@@ -393,19 +404,19 @@ test("questing stats count treasures earned", () => {
   );
   handleQuestRevealed(questRevealedEvent);
 
-  // Assert user data is updated
-  assert.fieldEquals(
-    USER_ENTITY_TYPE,
-    USER_ADDRESS,
-    "questingTreasuresEarned",
-    "1"
-  );
-
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
     assert.fieldEquals(
       QUESTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "questingTreasuresEarned",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
       "questingTreasuresEarned",
       "1"
     );
@@ -451,38 +462,6 @@ test("questing stats count quests finished", () => {
   );
   handleQuestStartedWithDifficulty(questStartedEvent);
 
-  for (let i = 0; i < statIds.length; i++) {
-    // Assert all time intervals are created
-    assert.fieldEquals(
-      QUESTING_STAT_ENTITY_TYPE,
-      statIds[i],
-      "questsStarted",
-      "1"
-    );
-    assert.fieldEquals(
-      QUESTING_STAT_ENTITY_TYPE,
-      statIds[i],
-      "activeAddressesCount",
-      "1"
-    );
-
-    // Assert all time intervals for legion type are created
-    assert.fieldEquals(
-      LEGION_STAT_ENTITY_TYPE,
-      `${statIds[i]}-genesis-common`,
-      "questsStarted",
-      "1"
-    );
-
-    // Assert all time intervals for difficulty are created
-    assert.fieldEquals(
-      QUESTING_DIFFICULTY_STAT_ENTITY_TYPE,
-      `${statIds[i]}-difficultyEasy`,
-      "questsStarted",
-      "1"
-    );
-  }
-
   const questFinishedEvent = createQuestFinishedEvent(
     timestamp,
     USER_ADDRESS,
@@ -501,8 +480,22 @@ test("questing stats count quests finished", () => {
     assert.fieldEquals(
       QUESTING_STAT_ENTITY_TYPE,
       statIds[i],
+      "allAddressesCount",
+      "1"
+    );
+    assert.fieldEquals(
+      QUESTING_STAT_ENTITY_TYPE,
+      statIds[i],
       "activeAddressesCount",
       "0"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "questsFinished",
+      "1"
     );
 
     // Assert all time intervals for legion type are created

--- a/subgraphs/bridgeworld-stats/tests/summoning/summoning.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/summoning/summoning.test.ts
@@ -12,6 +12,7 @@ import {
   LEGION_STAT_ENTITY_TYPE,
   SUMMONING_STAT_ENTITY_TYPE,
   USER_ADDRESS,
+  USER_STAT_ENTITY_TYPE,
 } from "../utils";
 import {
   createSummoningFinishedEvent,
@@ -75,6 +76,14 @@ test("summoning stats count summons started", () => {
       SUMMONING_STAT_ENTITY_TYPE,
       statIds[i],
       "activeAddressesCount",
+      "1"
+    );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "summonsStarted",
       "1"
     );
 
@@ -177,6 +186,12 @@ test("summoning stats count summons started", () => {
     "1"
   );
   assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `${statIds[0]}-${USER_ADDRESS}`,
+    "summonsStarted",
+    "1"
+  );
+  assert.fieldEquals(
     SUMMONING_STAT_ENTITY_TYPE,
     statIds[1],
     "magicSpent",
@@ -189,6 +204,12 @@ test("summoning stats count summons started", () => {
     "1"
   );
   assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `${statIds[1]}-${USER_ADDRESS}`,
+    "summonsStarted",
+    "1"
+  );
+  assert.fieldEquals(
     SUMMONING_STAT_ENTITY_TYPE,
     statIds[2],
     "magicSpent",
@@ -197,6 +218,12 @@ test("summoning stats count summons started", () => {
   assert.fieldEquals(
     SUMMONING_STAT_ENTITY_TYPE,
     statIds[2],
+    "summonsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `${statIds[2]}-${USER_ADDRESS}`,
     "summonsStarted",
     "1"
   );
@@ -220,6 +247,12 @@ test("summoning stats count summons started", () => {
     "activeAddressesCount",
     "1"
   );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `20220116-weekly-${Address.zero().toHexString()}`,
+    "summonsStarted",
+    "1"
+  );
 
   // Assert new monthly interval was created
   assert.fieldEquals(
@@ -238,6 +271,12 @@ test("summoning stats count summons started", () => {
     SUMMONING_STAT_ENTITY_TYPE,
     "202201-monthly",
     "activeAddressesCount",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `202201-monthly-${Address.zero().toHexString()}`,
+    "summonsStarted",
     "1"
   );
 
@@ -260,6 +299,18 @@ test("summoning stats count summons started", () => {
     "activeAddressesCount",
     "2"
   );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `2022-yearly-${USER_ADDRESS}`,
+    "summonsStarted",
+    "1"
+  );
+  assert.fieldEquals(
+    USER_STAT_ENTITY_TYPE,
+    `2022-yearly-${Address.zero().toHexString()}`,
+    "summonsStarted",
+    "1"
+  );
 });
 
 test("summoning stats count summons finished", () => {
@@ -277,22 +328,6 @@ test("summoning stats count summons finished", () => {
     1
   );
   handleSummoningStarted(summoningStartedEvent);
-
-  for (let i = 0; i < statIds.length; i++) {
-    // Assert all time intervals are created
-    assert.fieldEquals(
-      SUMMONING_STAT_ENTITY_TYPE,
-      statIds[i],
-      "summonsStarted",
-      "1"
-    );
-    assert.fieldEquals(
-      SUMMONING_STAT_ENTITY_TYPE,
-      statIds[i],
-      "activeAddressesCount",
-      "1"
-    );
-  }
 
   const summoningFinishedEvent = createSummoningFinishedEvent(
     timestamp,
@@ -316,14 +351,22 @@ test("summoning stats count summons finished", () => {
       "activeAddressesCount",
       "0"
     );
-
-    // Assert all time intervals for legion type are created
     assert.fieldEquals(
-      LEGION_STAT_ENTITY_TYPE,
-      `${statIds[i]}-genesis-common`,
-      "summonsStarted",
+      SUMMONING_STAT_ENTITY_TYPE,
+      statIds[i],
+      "allAddressesCount",
       "1"
     );
+
+    // Assert all time intervals for user are created
+    assert.fieldEquals(
+      USER_STAT_ENTITY_TYPE,
+      `${statIds[i]}-${USER_ADDRESS}`,
+      "summonsFinished",
+      "1"
+    );
+
+    // Assert all time intervals for legion type are created
     assert.fieldEquals(
       LEGION_STAT_ENTITY_TYPE,
       `${statIds[i]}-genesis-common`,

--- a/subgraphs/bridgeworld-stats/tests/utils.ts
+++ b/subgraphs/bridgeworld-stats/tests/utils.ts
@@ -1,3 +1,5 @@
+export const ATLAS_MINE_STAT_ENTITY_TYPE = "AtlasMineStat";
+export const ATLAS_MINE_LOCK_STAT_ENTITY_TYPE = "AtlasMineLockStat";
 export const CRAFTING_STAT_ENTITY_TYPE = "CraftingStat";
 export const CRAFTING_DIFFICULTY_STAT_ENTITY_TYPE = "CraftingDifficultyStat";
 export const LEGION_STAT_ENTITY_TYPE = "LegionStat";
@@ -5,6 +7,6 @@ export const SUMMONING_STAT_ENTITY_TYPE = "SummoningStat";
 export const QUESTING_STAT_ENTITY_TYPE = "QuestingStat";
 export const QUESTING_DIFFICULTY_STAT_ENTITY_TYPE = "QuestingDifficultyStat";
 export const TREASURE_STAT_ENTITY_TYPE = "TreasureStat";
-export const USER_ENTITY_TYPE = "User";
+export const USER_STAT_ENTITY_TYPE = "UserStat";
 
 export const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";


### PR DESCRIPTION
Refactors the way we're logging user-based stats to avoid storing large arrays of addresses. Also gives the added benefit of having user stats per time interval.