### PR TITLE
[bridgeworld-stats] remove unused event handler

### DIFF
--- a/subgraphs/bridgeworld-stats/template.yaml
+++ b/subgraphs/bridgeworld-stats/template.yaml
@@ -123,8 +123,6 @@ dataSources:
           handler: handlePilgrimagesStarted
         - event: PilgrimagesFinished(indexed address,uint256[],uint256[])
           handler: handlePilgrimagesFinished
-        - event: NoPilgrimagesToFinish(indexed address)
-          handler: handleNoPilgrimagesToFinish
       file: ./src/mappings/pilgrimage.ts
   - name: Questing
     kind: ethereum/contract


### PR DESCRIPTION
Fixes the `bridgeworld-stats` syncing error by removing the unused/unmapped event handler for `NoPilgrimagesToFinish`

```
Subgraph failed with non-deterministic error: failed to process trigger: block #5043950 (0x3e88…1270), transaction 8c0fbc5a1a3724c2981f4402970bc3c18a63a79210e1696d2a0adc8e0e3e663a: function handleNoPilgrimagesToFinish not found, retry_delay_s: 1800, attempt: 5
```