### PR TITLE
[bridgeworld-stats] fix all-class legion class enum

### DIFF
--- a/subgraphs/bridgeworld-stats/schema.graphql
+++ b/subgraphs/bridgeworld-stats/schema.graphql
@@ -31,7 +31,7 @@ enum LegionClass {
   Spellcaster
   Riverman
   Numeraire
-  "All-Class"
+  AllClass
   Origin
 }
 

--- a/subgraphs/bridgeworld-stats/src/helpers/constants.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/constants.ts
@@ -11,7 +11,7 @@ export const LEGION_CLASSES = [
   "Spellcaster",
   "Riverman",
   "Numeraire",
-  "All-Class",
+  "AllClass",
   "Origin",
 ];
 

--- a/subgraphs/bridgeworld-stats/src/helpers/models.ts
+++ b/subgraphs/bridgeworld-stats/src/helpers/models.ts
@@ -85,7 +85,12 @@ export function getLegionName(
     return customName;
   }
 
-  return `${LEGION_GENERATIONS[generation]} ${LEGION_RARITIES[rarity]}`;
+  const generationStr = LEGION_GENERATIONS[generation];
+  if (generationStr == "Recruit") {
+    return generationStr;
+  }
+
+  return `${generationStr} ${LEGION_RARITIES[rarity]}`;
 }
 
 export function getLegionSummonCost(generation: string): BigInt {

--- a/subgraphs/bridgeworld-stats/src/mappings/pilgrimage.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/pilgrimage.ts
@@ -91,6 +91,7 @@ export function handlePilgrimagesFinished(event: PilgrimagesFinished): void {
         stat.endTimestamp,
         true
       );
+      legionStat.pilgrimageStat = stat.id;
       legionStat.pilgrimagesResulted += 1;
       legionStat.save();
     }

--- a/subgraphs/bridgeworld-stats/tests/helpers/models.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/helpers/models.test.ts
@@ -1,0 +1,40 @@
+import { assert, test } from "matchstick-as";
+
+import { BigInt } from "@graphprotocol/graph-ts";
+
+import { getLegionName } from "../../src/helpers/models";
+
+test("legion name is correct", () => {
+  let result = getLegionName(BigInt.fromI32(523), 0, 0);
+  assert.stringEquals(result, "Bombmaker");
+
+  result = getLegionName(BigInt.fromI32(1629), 0, 0);
+  assert.stringEquals(result, "Warlock");
+
+  result = getLegionName(BigInt.fromI32(1744), 0, 0);
+  assert.stringEquals(result, "Fallen");
+
+  result = getLegionName(BigInt.fromI32(2239), 0, 0);
+  assert.stringEquals(result, "Dreamwinder");
+
+  result = getLegionName(BigInt.fromI32(3476), 0, 0);
+  assert.stringEquals(result, "Clocksnatcher");
+
+  result = getLegionName(BigInt.zero(), 0, 1);
+  assert.stringEquals(result, "Genesis Rare");
+
+  result = getLegionName(BigInt.zero(), 0, 2);
+  assert.stringEquals(result, "Genesis Special");
+
+  result = getLegionName(BigInt.zero(), 0, 3);
+  assert.stringEquals(result, "Genesis Uncommon");
+
+  result = getLegionName(BigInt.zero(), 0, 4);
+  assert.stringEquals(result, "Genesis Common");
+
+  result = getLegionName(BigInt.zero(), 1, 3);
+  assert.stringEquals(result, "Auxiliary Uncommon");
+
+  result = getLegionName(BigInt.zero(), 2, 5);
+  assert.stringEquals(result, "Recruit");
+});


### PR DESCRIPTION
- Fixes #97 
- Fixes the subgraph sync error:

```
Subgraph failed with non-deterministic error: Error while processing block stream for a subgraph: store error: invalid input value for enum sgd238069.legion_class: "All-Class", retry_delay_s: 1800, attempt: 14
```