### PR TITLE
[bridgeworld-stats] attempt to fix pilgrimage stat counts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -113,6 +113,9 @@ jobs:
         env:
           GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
         run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
+      - name: Deploy to DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn deploy:dev
       - name: Deploy to PROD
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: yarn deploy:prod

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,7 +109,6 @@ jobs:
       - name: Test
         run: yarn test
       - name: Authenticate
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
         run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
     "@graphprotocol/graph-ts": "0.24.1",
     "@trivago/prettier-plugin-sort-imports": "3.2.0",
     "husky": "7.0.4",
-    "lint-staged": "12.3.4",
+    "lint-staged": "12.3.5",
     "matchstick-as": "0.4.0",
     "mustache": "4.2.0",
-    "prettier": "2.5.1",
-    "typescript": "4.5.5"
+    "prettier": "2.5.1"
   },
   "resolutions": {
     "colors": "1.4.0"

--- a/subgraphs/bridgeworld-stats/package.json
+++ b/subgraphs/bridgeworld-stats/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "codegen": "graph codegen",
+    "deploy:dev": "graph deploy --product hosted-service treasureproject/bridgeworld-stats-dev",
     "deploy:prod": "graph deploy --product hosted-service treasureproject/bridgeworld-stats",
     "prepare:dev": "yarn --cwd ../../packages/constants prepare:arbitrum-testnet && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:prod": "yarn --cwd ../../packages/constants prepare:arbitrum && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",

--- a/subgraphs/bridgeworld-stats/src/mappings/pilgrimage.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/pilgrimage.ts
@@ -1,4 +1,4 @@
-import { log } from "@graphprotocol/graph-ts";
+import { BigInt, log } from "@graphprotocol/graph-ts";
 
 import {
   PilgrimagesFinished,
@@ -51,7 +51,11 @@ export function handlePilgrimagesStarted(event: PilgrimagesStarted): void {
 export function handlePilgrimagesFinished(event: PilgrimagesFinished): void {
   const params = event.params;
   const tokenIds = params._tokenIds;
-  const pilgrimagesCount = params._finishedPilgrimageIds.length;
+
+  // Only include non-zero pilgrimage IDs in finished count
+  const pilgrimagesCount = params._finishedPilgrimageIds.filter((id) =>
+    id.gt(BigInt.zero())
+  ).length;
 
   const stats = getTimeIntervalPilgrimageStats(event.block);
   for (let i = 0; i < stats.length; i++) {

--- a/subgraphs/bridgeworld-stats/src/mappings/pilgrimage.ts
+++ b/subgraphs/bridgeworld-stats/src/mappings/pilgrimage.ts
@@ -13,11 +13,10 @@ import {
 
 export function handlePilgrimagesStarted(event: PilgrimagesStarted): void {
   const params = event.params;
-  const tokenIds = params._ids1155;
   const tokenAmounts = params._amounts1155;
 
   let pilgrimagesCount = 0;
-  for (let i = 0; i < tokenIds.length; i++) {
+  for (let i = 0; i < tokenAmounts.length; i++) {
     pilgrimagesCount += tokenAmounts[i].toI32();
   }
 
@@ -52,11 +51,12 @@ export function handlePilgrimagesStarted(event: PilgrimagesStarted): void {
 export function handlePilgrimagesFinished(event: PilgrimagesFinished): void {
   const params = event.params;
   const tokenIds = params._tokenIds;
+  const pilgrimagesCount = params._finishedPilgrimageIds.length;
 
   const stats = getTimeIntervalPilgrimageStats(event.block);
   for (let i = 0; i < stats.length; i++) {
     const stat = stats[i];
-    stat.pilgrimagesFinished += tokenIds.length;
+    stat.pilgrimagesFinished += pilgrimagesCount;
 
     const userStat = getOrCreateUserStat(
       stat.id,
@@ -65,7 +65,7 @@ export function handlePilgrimagesFinished(event: PilgrimagesFinished): void {
       stat.endTimestamp,
       stat.interval
     );
-    userStat.pilgrimagesFinished += tokenIds.length;
+    userStat.pilgrimagesFinished += pilgrimagesCount;
     userStat.save();
 
     if (userStat.pilgrimagesStarted == userStat.pilgrimagesFinished) {

--- a/subgraphs/bridgeworld-stats/tests/pilgrimage/pilgrimage.test.ts
+++ b/subgraphs/bridgeworld-stats/tests/pilgrimage/pilgrimage.test.ts
@@ -43,7 +43,7 @@ test("pilgrimage stats count pilgrimages started", () => {
     0,
     [1, 2, 3],
     [1, 2, 1],
-    [0, 1, 2]
+    [1, 2, 3]
   );
   handlePilgrimagesStarted(pilgrimagesStartedEvent);
 
@@ -140,7 +140,7 @@ test("pilgrimage stats count pilgrimages started", () => {
     0,
     [4, 5, 6],
     [1, 1, 1],
-    [3, 4, 5]
+    [4, 5, 6]
   );
   handlePilgrimagesStarted(pilgrimagesStartedEvent2);
 
@@ -180,24 +180,21 @@ test("pilgrimage stats count pilgrimages finished", () => {
   handleLegionCreated(createLegionCreatedEvent(1, 1, 4, 3));
   handleLegionCreated(createLegionCreatedEvent(2, 1, 4, 3));
 
-  const pilgrimagesStartedEvent = createPilgrimagesStartedEvent(
-    timestamp,
-    USER_ADDRESS,
-    Address.zero().toHexString(),
-    0,
-    [1, 2],
-    [1, 1],
-    [0, 1]
+  handlePilgrimagesStarted(
+    createPilgrimagesStartedEvent(
+      timestamp,
+      USER_ADDRESS,
+      Address.zero().toHexString(),
+      0,
+      [1, 2],
+      [1, 1],
+      [1, 2]
+    )
   );
-  handlePilgrimagesStarted(pilgrimagesStartedEvent);
 
-  const pilgrimageFinishedEvent = createPilgrimagesFinishedEvent(
-    timestamp,
-    USER_ADDRESS,
-    [1, 2],
-    [0, 1]
+  handlePilgrimagesFinished(
+    createPilgrimagesFinishedEvent(timestamp, USER_ADDRESS, [1, 2], [1, 0, 2])
   );
-  handlePilgrimagesFinished(pilgrimageFinishedEvent);
 
   for (let i = 0; i < statIds.length; i++) {
     // Assert all time intervals are created
@@ -242,7 +239,7 @@ test("pilgrimage stats track addresses", () => {
       0,
       [1],
       [1],
-      [0]
+      [1]
     )
   );
   handlePilgrimagesStarted(
@@ -253,7 +250,7 @@ test("pilgrimage stats track addresses", () => {
       0,
       [2],
       [1],
-      [1]
+      [2]
     )
   );
 
@@ -262,7 +259,7 @@ test("pilgrimage stats track addresses", () => {
 
   // One user becomes inactive
   handlePilgrimagesFinished(
-    createPilgrimagesFinishedEvent(timestamp, USER_ADDRESS, [1], [0])
+    createPilgrimagesFinishedEvent(timestamp, USER_ADDRESS, [1], [1])
   );
 
   assert.fieldEquals(STAT_ENTITY_TYPE, "all-time", "allAddressesCount", "2");
@@ -277,7 +274,7 @@ test("pilgrimage stats track addresses", () => {
       0,
       [3],
       [1],
-      [2]
+      [3]
     )
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,10 +2083,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lint-staged@12.3.4:
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.3.4.tgz#4b1ff8c394c3e6da436aaec5afd4db18b5dac360"
-  integrity sha512-yv/iK4WwZ7/v0GtVkNb3R82pdL9M+ScpIbJLJNyCXkJ1FGaXvRCOg/SeL59SZtPpqZhE7BD6kPKFLIDUhDx2/w==
+lint-staged@12.3.5:
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.3.5.tgz#8048ce048c3cac12f57200a06344a54dc91c8fa9"
+  integrity sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==
   dependencies:
     cli-truncate "^3.1.0"
     colorette "^2.0.16"
@@ -3363,11 +3363,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 unique-by@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Updates packages
- Attempts to fix an issue seen in the Pilgrimage stats with some count clean-up

@wyze any other reason you can see for this mismatch?

```
{
  "data": {
    "pilgrimageStat": {
      "pilgrimagesStarted": 4359,
      "pilgrimagesFinished": 4397,
      "activeAddressesCount": 19,
      "allAddressesCount": 1680
    }
  }
}
```

Finished count is somehow more than started count in the synced production subgraph 🤔 