### PR TITLE
Add Seed of Life Stats subgraph; fix broken token parsing on Seed of Life subgraph

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,7 @@ jobs:
       metadata: ${{ steps.filter.outputs.metadata }}
       migration: ${{ steps.filter.outputs.migration }}
       seed_of_life: ${{ steps.filter.outputs.seed_of_life }}
+      seed_of_life_stats: ${{ steps.filter.outputs.seed_of_life_stats }}
       smolverse: ${{ steps.filter.outputs.smolverse }}
       snapshot: ${{ steps.filter.outputs.snapshot }}
     steps:
@@ -44,6 +45,9 @@ jobs:
           seed_of_life:
             - "packages/**"
             - "subgraphs/seed-of-life/**"
+          seed_of_life_stats:
+            - "packages/**"
+            - "subgraphs/seed-of-life-stats/**"
           smolverse:
             - "packages/**"
             - "subgraphs/smolverse/**"
@@ -241,6 +245,44 @@ jobs:
     defaults:
       run:
         working-directory: ./subgraphs/seed-of-life
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Prepare for DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn prepare:dev
+      - name: Prepare for PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn prepare:prod
+      - name: Generate code
+        run: yarn codegen
+      - name: Test
+        run: yarn test
+      - name: Authenticate
+        env:
+          GRAPH_ACCESS_TOKEN: ${{ secrets.GRAPH_ACCESS_TOKEN }}
+        run: yarn graph auth --product hosted-service "$GRAPH_ACCESS_TOKEN"
+      - name: Deploy to DEV
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: yarn deploy:dev
+      - name: Deploy to PROD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: yarn deploy:prod
+
+  seed_of_life_stats:
+    name: Seed of Life Stats Subgraph
+    if: ${{ needs.changes.outputs.seed_of_life_stats == 'true' }}
+    needs: changes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./subgraphs/seed-of-life-stats
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/packages/abis/src/SeedEvolution.json
+++ b/packages/abis/src/SeedEvolution.json
@@ -11,13 +11,13 @@
             {
                 "indexed": false,
                 "internalType": "uint256[]",
-                "name": "_brokenTreasureIds",
+                "name": "_unstakingTreasureIds",
                 "type": "uint256[]"
             },
             {
                 "indexed": false,
                 "internalType": "uint256[]",
-                "name": "_brokenTreasureAmounts",
+                "name": "_unstakingTreasureAmounts",
                 "type": "uint256[]"
             }
         ],

--- a/subgraphs/seed-of-life-stats/matchstick.yaml
+++ b/subgraphs/seed-of-life-stats/matchstick.yaml
@@ -1,0 +1,1 @@
+libsFolder: ../../node_modules/

--- a/subgraphs/seed-of-life-stats/package.json
+++ b/subgraphs/seed-of-life-stats/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "seed-of-life-stats",
+  "version": "1.0.0",
+  "description": "Subgraph that powers Seed of Life Statistics",
+  "license": "MIT",
+  "scripts": {
+    "codegen": "graph codegen",
+    "deploy:dev": "graph deploy --product hosted-service treasureproject/seed-of-life-stats-dev",
+    "deploy:prod": "graph deploy --product hosted-service treasureproject/seed-of-life-stats",
+    "prepare:dev": "yarn --cwd ../../packages/constants prepare:arbitrum-testnet && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
+    "prepare:prod": "yarn --cwd ../../packages/constants prepare:arbitrum && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
+    "test": "graph test"
+  }
+}

--- a/subgraphs/seed-of-life-stats/schema.graphql
+++ b/subgraphs/seed-of-life-stats/schema.graphql
@@ -1,0 +1,118 @@
+enum Path {
+  NO_MAGIC
+  MAGIC
+  MAGIC_AND_BC
+}
+
+enum LifeformRealm {
+  VESPER
+  SHERWOOD
+  THOUSAND_ISLES
+  TUL_NIELOHG_DESERT
+  DULKHAN_MOUNTAINS
+  MOLTANIA
+  NETHEREALM
+  MAGINCIA
+}
+
+enum LifeformClass {
+  WARRIOR
+  MAGE
+  PRIEST
+  SHARPSHOOTER
+  SUMMONER
+  PALADIN
+  ASURA
+  SLAYER
+}
+
+type _Lifeform @entity {
+  id: ID!
+
+  firstRealm: LifeformRealm!
+  secondRealm: LifeformRealm!
+  path: Path!
+  stakedTreasureIds: [BigInt!]!
+  stakedTreasureAmounts: [BigInt!]!
+}
+
+type _LifeformOwner @entity {
+  id: ID!
+
+  lifeform: _Lifeform!
+}
+
+type _Random @entity {
+  id: ID!
+
+  lifeformId: String
+}
+
+type _Seeded @entity {
+  id: ID!
+
+  randomIds: [String!]!
+}
+
+type RealmStat @entity {
+  id: ID!
+
+  realm: LifeformRealm!
+
+  "Number of Lifeforms in this realm"
+  lifeformTotal: BigInt!
+
+  "Number of Lifeforms birthed in this realm"
+  firstRealmCount: BigInt!
+
+  "Number of Lifeforms brought up in this realm"
+  secondRealmCount: BigInt!
+}
+
+type PathStat @entity {
+  id: ID!
+
+  path: Path!
+
+  "Number of Lifeforms on this path"
+  lifeformTotal: BigInt!
+}
+
+type TreasureStat @entity {
+  id: ID!
+
+  tokenId: BigInt!
+  name: String!
+  tier: Int!
+
+  "Number of this treasure staked"
+  staked: BigInt!
+
+  "Number of this treasure unstaked"
+  unstaked: BigInt!
+
+  "Number of this treasure broken"
+  broken: BigInt!
+}
+
+type ClassStat @entity {
+  id: ID!
+
+  lifeformClass: LifeformClass!
+
+  "Number of Lifeforms of this class"
+  lifeformTotal: BigInt!
+}
+
+type GlobalStat @entity {
+  id: ID!
+
+  lifeformTotal: BigInt!
+
+  magicOffered: BigInt!
+  balancerCrystalsStaked: BigInt!
+
+  treasuresStaked: BigInt!
+  treasuresUnstaked: BigInt!
+  treasuresBroken: BigInt!
+}

--- a/subgraphs/seed-of-life-stats/src/helpers/constants.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/constants.ts
@@ -1,0 +1,31 @@
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+
+// Numbers
+export const ZERO_BI = BigInt.fromI32(0);
+export const ONE_BI = BigInt.fromI32(1);
+export const ONE_WEI = BigDecimal.fromString((1e18).toString());
+
+// Seed of Life
+export const ORDERED_REALMS = [
+  "VESPER",
+  "SHERWOOD",
+  "THOUSAND_ISLES",
+  "TUL_NIELOHG_DESERT",
+  "DULKHAN_MOUNTAINS",
+  "MOLTANIA",
+  "NETHEREALM",
+  "MAGINCIA",
+];
+
+export const ORDERED_PATHS = ["NO_MAGIC", "MAGIC", "MAGIC_AND_BC"];
+
+export const ORDERED_CLASSES = [
+  "WARRIOR",
+  "MAGE",
+  "PRIEST",
+  "SHARPSHOOTER",
+  "SUMMONER",
+  "PALADIN",
+  "ASURA",
+  "SLAYER",
+];

--- a/subgraphs/seed-of-life-stats/src/helpers/lifeform.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/lifeform.ts
@@ -1,0 +1,31 @@
+import { Address, BigInt, log } from "@graphprotocol/graph-ts";
+
+import { _Lifeform, _LifeformOwner } from "../../generated/schema";
+import { ORDERED_CLASSES } from "./constants";
+
+export const getOrCreateLifeform = (
+  tokenId: BigInt,
+  owner: Address
+): _Lifeform => {
+  const id = tokenId.toHexString();
+  let lifeform = _Lifeform.load(id);
+  if (!lifeform) {
+    lifeform = new _Lifeform(id);
+    lifeform.save();
+
+    const lifeformOwner = new _LifeformOwner(owner.toHexString());
+    lifeformOwner.lifeform = lifeform.id;
+    lifeformOwner.save();
+  }
+
+  return lifeform;
+};
+
+export const getLifeformClassByIndex = (index: i32): string => {
+  if (index < 0 || index > ORDERED_CLASSES.length) {
+    log.error("Unknown Lifeform class index: {}", [index.toString()]);
+    return "Unknown";
+  }
+
+  return ORDERED_CLASSES[index];
+};

--- a/subgraphs/seed-of-life-stats/src/helpers/number.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/number.ts
@@ -1,0 +1,8 @@
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+
+import { ONE_WEI } from "./constants";
+
+export const etherToWei = (ether: f64): BigInt =>
+  BigInt.fromString(
+    BigDecimal.fromString(ether.toString()).times(ONE_WEI).toString()
+  );

--- a/subgraphs/seed-of-life-stats/src/helpers/path.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/path.ts
@@ -1,0 +1,19 @@
+import { BigInt, log } from "@graphprotocol/graph-ts";
+
+import { ONE_BI, ORDERED_PATHS, ZERO_BI } from "./constants";
+import { etherToWei } from "./number";
+
+export const getPathByIndex = (index: i32): string => {
+  if (index < 0 || index > ORDERED_PATHS.length) {
+    log.error("Unknown path index: {}", [index.toString()]);
+    return "Unknown";
+  }
+
+  return ORDERED_PATHS[index];
+};
+
+export const getMagicOfferedForPath = (index: i32): BigInt =>
+  index >= 1 ? etherToWei(50) : ZERO_BI;
+
+export const getBalancerCrystalsStakedForPath = (index: i32): BigInt =>
+  index === 2 ? ONE_BI : ZERO_BI;

--- a/subgraphs/seed-of-life-stats/src/helpers/random.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/random.ts
@@ -1,0 +1,28 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
+import { _Random, _Seeded } from "../../generated/schema";
+
+export const getOrCreateRandom = (requestId: BigInt): _Random => {
+  const id = requestId.toHexString();
+  let random = _Random.load(id);
+
+  if (!random) {
+    random = new _Random(id);
+    random.save();
+  }
+
+  return random;
+};
+
+export const getOrCreateSeeded = (commitId: BigInt): _Seeded => {
+  const id = commitId.toHexString();
+  let seeded = _Seeded.load(id);
+
+  if (!seeded) {
+    seeded = new _Seeded(id);
+    seeded.randomIds = [];
+    seeded.save();
+  }
+
+  return seeded;
+};

--- a/subgraphs/seed-of-life-stats/src/helpers/realm.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/realm.ts
@@ -1,0 +1,12 @@
+import { log } from "@graphprotocol/graph-ts";
+
+import { ORDERED_REALMS } from "./constants";
+
+export const getRealmByIndex = (index: i32): string => {
+  if (index < 0 || index > ORDERED_REALMS.length) {
+    log.error("Unknown realm index: {}", [index.toString()]);
+    return "Unknown";
+  }
+
+  return ORDERED_REALMS[index];
+};

--- a/subgraphs/seed-of-life-stats/src/helpers/stat.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/stat.ts
@@ -1,0 +1,71 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
+import {
+  ClassStat,
+  GlobalStat,
+  PathStat,
+  RealmStat,
+  TreasureStat,
+} from "../../generated/schema";
+import { getTokenName, getTreasureTier } from "./treasure";
+
+export const getOrCreateRealmStat = (realm: string): RealmStat => {
+  const id = realm;
+  let stat = RealmStat.load(id);
+  if (!stat) {
+    stat = new RealmStat(id);
+    stat.realm = realm;
+    stat.save();
+  }
+
+  return stat;
+};
+
+export const getOrCreatePathStat = (path: string): PathStat => {
+  const id = path;
+  let stat = PathStat.load(id);
+  if (!stat) {
+    stat = new PathStat(id);
+    stat.path = path;
+    stat.save();
+  }
+
+  return stat;
+};
+
+export const getOrCreateTreasureStat = (tokenId: BigInt): TreasureStat => {
+  const id = tokenId.toHexString();
+  let stat = TreasureStat.load(id);
+  if (!stat) {
+    stat = new TreasureStat(id);
+    stat.tokenId = tokenId;
+    stat.name = getTokenName(tokenId);
+    stat.tier = getTreasureTier(tokenId);
+    stat.save();
+  }
+
+  return stat;
+};
+
+export const getOrCreateClassStat = (lifeformClass: string): ClassStat => {
+  const id = lifeformClass;
+  let stat = ClassStat.load(id);
+  if (!stat) {
+    stat = new ClassStat(id);
+    stat.lifeformClass = lifeformClass;
+    stat.save();
+  }
+
+  return stat;
+};
+
+export const getOrCreateGlobalStat = (): GlobalStat => {
+  const id = "only";
+  let stat = GlobalStat.load(id);
+  if (!stat) {
+    stat = new GlobalStat(id);
+    stat.save();
+  }
+
+  return stat;
+};

--- a/subgraphs/seed-of-life-stats/src/helpers/treasure.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/treasure.ts
@@ -1,0 +1,261 @@
+import { BigInt, log } from "@graphprotocol/graph-ts";
+
+export const getTokenName = (tokenId: BigInt): string => {
+  const id = tokenId.toI32();
+  switch (id) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+    case 8:
+    case 9:
+    case 10:
+    case 11:
+    case 12:
+    case 13:
+    case 14:
+    case 15:
+    case 16:
+    case 17:
+    case 18:
+    case 19:
+    case 20:
+    case 21:
+    case 22:
+    case 23:
+    case 24:
+    case 25:
+    case 26:
+    case 27:
+    case 28:
+    case 29:
+    case 30:
+    case 31:
+    case 32:
+    case 33:
+    case 34:
+    case 35:
+    case 36:
+    case 37:
+    case 38:
+      return `All-Class ${id}`;
+    case 39:
+      return "Ancient Relic";
+    case 40:
+    case 41:
+    case 42:
+    case 43:
+    case 44:
+      return `Assassin ${id - 39}`;
+    case 45:
+      return "Assassin";
+    case 46:
+      return "Bag of Rare Mushrooms";
+    case 47:
+      return "Bait for Monsters";
+    case 48:
+      return "Beetle-wing";
+    case 49:
+      return "Blue Rupee";
+    case 50:
+      return "Bombmaker";
+    case 51:
+      return "Bottomless Elixir";
+    case 52:
+      return "Cap of Invisibility";
+    case 53:
+      return "Carriage";
+    case 54:
+      return "Castle";
+    case 55:
+      return "Clocksnatcher";
+    case 56:
+    case 57:
+    case 58:
+    case 59:
+    case 60:
+    case 61:
+    case 62:
+    case 63:
+    case 64:
+    case 65:
+    case 66:
+    case 67:
+      return `Common ${id - 55}`;
+    case 68:
+      return "Common Bead";
+    case 69:
+      return "Common Feather";
+    case 70:
+      return "Common Legion";
+    case 71:
+      return "Common Relic";
+    case 72:
+      return "Cow";
+    case 73:
+      return "Diamond";
+    case 74:
+      return "Divine Hourglass";
+    case 75:
+      return "Divine Mask";
+    case 76:
+      return "Donkey";
+    case 77:
+      return "Dragon Tail";
+    case 78:
+      return "Dreamwinder";
+    case 79:
+      return "Emerald";
+    case 80:
+      return "Extra Life";
+    case 81:
+      return "Fallen";
+    case 82:
+      return "Favor from the Gods";
+    case 83:
+    case 84:
+    case 85:
+    case 86:
+    case 87:
+    case 88:
+    case 89:
+      return `Fighter ${id - 82}`;
+    case 90:
+      return "Fighter";
+    case 91:
+      return "Framed Butterfly";
+    case 92:
+      return "Gold Coin";
+    case 93:
+      return "Grain";
+    case 94:
+      return "Green Rupee";
+    case 95:
+      return "Grin";
+    case 96:
+      return "Half-Penny";
+    case 97:
+      return "Honeycomb";
+    case 98:
+      return "Immovable Stone";
+    case 99:
+      return "Ivory Breastpin";
+    case 100:
+      return "Jar of Fairies";
+    case 102:
+      return "Keys";
+    case 103:
+      return "Lumber";
+    case 104:
+      return "Military Stipend";
+    case 105:
+      return "Mollusk Shell";
+    case 106:
+    case 107:
+    case 108:
+    case 109:
+    case 110:
+    case 111:
+    case 112:
+    case 113:
+      return `Numeraire ${id - 105}`;
+    case 114:
+      return "Ox";
+    case 115:
+      return "Pearl";
+    case 116:
+      return "Pot of Gold";
+    case 117:
+      return "Quarter-Penny";
+    case 118:
+    case 119:
+    case 120:
+    case 121:
+    case 122:
+    case 123:
+    case 124:
+    case 125:
+    case 126:
+    case 127:
+    case 128:
+    case 129:
+    case 130:
+      return `Range ${id - 117}`;
+    case 131:
+      return "Range";
+    case 132:
+      return "Red Feather";
+    case 133:
+      return "Red Rupee";
+    case 134:
+    case 135:
+    case 136:
+    case 137:
+    case 138:
+    case 139:
+    case 140:
+      return `Riverman ${id - 133}`;
+    case 141:
+      return "Score of Ivory";
+    case 142:
+    case 143:
+      return `Seed of Life ${id - 141}`;
+    case 144:
+    case 145:
+    case 146:
+    case 147:
+    case 148:
+    case 149:
+      return `Siege ${id - 143}`;
+    case 150:
+      return "Siege";
+    case 151:
+      return "Silver Coin";
+    case 152:
+      return "Small Bird";
+    case 153:
+      return "Snow White Feather";
+    case 154:
+    case 155:
+    case 156:
+    case 157:
+    case 158:
+    case 159:
+      return `Spellcaster ${id - 153}`;
+    case 160:
+      return "Spellcaster";
+    case 161:
+      return "Thread of Divine Silk";
+    case 162:
+      return "Unbreakable Pocketwatch";
+    case 163:
+      return "Warlock";
+    case 164:
+      return "Witches Broom";
+    default:
+      log.error("Unknown treasure name: {}", [id.toString()]);
+      return "Unknown";
+  }
+};
+
+export const getTreasureTier = (tokenId: BigInt): i32 => {
+  const id = tokenId.toI32();
+  switch (true) {
+    case [54, 95, 39, 51, 97, 52].includes(id):
+      return 1;
+    case [99, 161, 74, 47, 132, 98, 153, 105, 46, 104, 53].includes(id):
+      return 2;
+    case [141, 68, 162, 75, 82, 91, 100, 152, 72, 116].includes(id):
+      return 3;
+    case [94, 71, 164, 93, 69, 49, 76, 103, 114].includes(id):
+      return 4;
+    case [73, 79, 115, 77, 48, 151, 96, 117, 133, 92].includes(id):
+      return 5;
+    default:
+      log.error("Unknown treasure tier: {}", [id.toString()]);
+      return 0;
+  }
+};

--- a/subgraphs/seed-of-life-stats/src/mappings/randomizer.ts
+++ b/subgraphs/seed-of-life-stats/src/mappings/randomizer.ts
@@ -1,0 +1,68 @@
+import { BigInt, log, store } from "@graphprotocol/graph-ts";
+
+import { SEED_EVOLUTION_ADDRESS } from "@treasure/constants";
+
+import {
+  RandomRequest,
+  RandomSeeded,
+} from "../../generated/Randomizer/Randomizer";
+import { SeedEvolution } from "../../generated/SeedEvolution/SeedEvolution";
+import { _Lifeform, _Random, _Seeded } from "../../generated/schema";
+import { ONE_BI } from "../helpers/constants";
+import { getLifeformClassByIndex } from "../helpers/lifeform";
+import { getOrCreateRandom, getOrCreateSeeded } from "../helpers/random";
+import { getOrCreateClassStat } from "../helpers/stat";
+
+export function handleRandomRequest(event: RandomRequest): void {
+  const params = event.params;
+  const random = getOrCreateRandom(params._requestId);
+  const seeded = getOrCreateSeeded(params._commitId);
+  seeded.randomIds = seeded.randomIds.concat([random.id]);
+  seeded.save();
+}
+
+export function handleRandomSeeded(event: RandomSeeded): void {
+  const params = event.params;
+
+  const seededId = params._commitId.toHexString();
+  const seeded = _Seeded.load(seededId);
+  if (!seeded) {
+    log.error("[randomizer] Unknown seeded: {}", [seededId]);
+    return;
+  }
+
+  const randomIds = seeded.randomIds;
+  for (let index = 0; index < randomIds.length; index++) {
+    const randomId = randomIds[index];
+    const random = _Random.load(randomId);
+    if (!random) {
+      log.error("[randomizer] Unknown random: {}", [randomId]);
+      continue;
+    }
+
+    // Shared randomizer
+    if (random.lifeformId) {
+      const lifeformId = random.lifeformId as string;
+      const lifeform = _Lifeform.load(lifeformId);
+      if (!lifeform) {
+        log.error("[randomizer] Unknown Lifeform: {}", [lifeformId]);
+        continue;
+      }
+
+      const contract = SeedEvolution.bind(SEED_EVOLUTION_ADDRESS);
+      const classCall = contract.try_classForLifeform(
+        BigInt.fromI32(parseInt(lifeform.id, 16) as i32)
+      );
+      if (!classCall.reverted) {
+        const lifeformClass = getLifeformClassByIndex(classCall.value);
+        const classStat = getOrCreateClassStat(lifeformClass);
+        classStat.lifeformTotal = classStat.lifeformTotal.plus(ONE_BI);
+        classStat.save();
+      }
+    }
+
+    store.remove("_Random", randomId);
+  }
+
+  store.remove("_Seeded", seededId);
+}

--- a/subgraphs/seed-of-life-stats/src/mappings/seed-evolution.ts
+++ b/subgraphs/seed-of-life-stats/src/mappings/seed-evolution.ts
@@ -1,0 +1,129 @@
+import { log } from "@graphprotocol/graph-ts";
+
+import {
+  FinishedUnstakingTreasure,
+  LifeformCreated,
+} from "../../generated/SeedEvolution/SeedEvolution";
+import { _Lifeform, _LifeformOwner } from "../../generated/schema";
+import { ONE_BI } from "../helpers/constants";
+import { getOrCreateLifeform } from "../helpers/lifeform";
+import {
+  getBalancerCrystalsStakedForPath,
+  getMagicOfferedForPath,
+  getPathByIndex,
+} from "../helpers/path";
+import { getOrCreateRandom } from "../helpers/random";
+import { getRealmByIndex } from "../helpers/realm";
+import {
+  getOrCreateGlobalStat,
+  getOrCreatePathStat,
+  getOrCreateRealmStat,
+  getOrCreateTreasureStat,
+} from "../helpers/stat";
+
+export function handleLifeformCreated(event: LifeformCreated): void {
+  const params = event.params;
+  const info = params._evolutionInfo;
+
+  const pathIndex = info.path;
+  const firstRealm = getRealmByIndex(info.firstRealm);
+  const secondRealm = getRealmByIndex(info.secondRealm);
+  const path = getPathByIndex(pathIndex);
+
+  const lifeform = getOrCreateLifeform(params._lifeformId, info.owner);
+  lifeform.firstRealm = firstRealm;
+  lifeform.secondRealm = secondRealm;
+  lifeform.path = path;
+  lifeform.stakedTreasureIds = info.stakedTreasureIds;
+  lifeform.stakedTreasureAmounts = info.stakedTreasureAmounts;
+  lifeform.save();
+
+  const random = getOrCreateRandom(info.requestId);
+  random.lifeformId = lifeform.id;
+  random.save();
+
+  // Increment global stats
+  const globalStat = getOrCreateGlobalStat();
+  globalStat.lifeformTotal = globalStat.lifeformTotal.plus(ONE_BI);
+  globalStat.magicOffered = globalStat.magicOffered.plus(
+    getMagicOfferedForPath(pathIndex)
+  );
+  globalStat.balancerCrystalsStaked = globalStat.balancerCrystalsStaked.plus(
+    getBalancerCrystalsStakedForPath(pathIndex)
+  );
+
+  // Increment realm stats
+  const firstRealmStat = getOrCreateRealmStat(firstRealm);
+  firstRealmStat.lifeformTotal = firstRealmStat.lifeformTotal.plus(ONE_BI);
+  firstRealmStat.firstRealmCount = firstRealmStat.firstRealmCount.plus(ONE_BI);
+  firstRealmStat.save();
+
+  const secondRealmStat = getOrCreateRealmStat(secondRealm);
+  secondRealmStat.lifeformTotal = secondRealmStat.lifeformTotal.plus(ONE_BI);
+  secondRealmStat.secondRealmCount =
+    secondRealmStat.secondRealmCount.plus(ONE_BI);
+  secondRealmStat.save();
+
+  // Increment path stats
+  const pathStat = getOrCreatePathStat(path);
+  pathStat.lifeformTotal = pathStat.lifeformTotal.plus(ONE_BI);
+  pathStat.save();
+
+  // Increment treasure stats
+  for (let i = 0; i < info.stakedTreasureIds.length; i++) {
+    const amount = info.stakedTreasureAmounts[i];
+    const treasureStat = getOrCreateTreasureStat(info.stakedTreasureIds[i]);
+    treasureStat.staked = treasureStat.staked.plus(amount);
+    treasureStat.save();
+
+    globalStat.treasuresStaked = globalStat.treasuresStaked.plus(amount);
+  }
+
+  globalStat.save();
+}
+
+export function handleFinishedUnstakingTreasure(
+  event: FinishedUnstakingTreasure
+): void {
+  const params = event.params;
+
+  const globalStat = getOrCreateGlobalStat();
+
+  const ownerId = params._owner.toHexString();
+  const lifeformOwner = _LifeformOwner.load(ownerId);
+  if (!lifeformOwner) {
+    log.error("Unknown Lifeform owner: {}", [ownerId]);
+    return;
+  }
+
+  const lifeform = _Lifeform.load(lifeformOwner.lifeform);
+  if (!lifeform) {
+    log.error("Unknown Lifeform owner: {}", [ownerId]);
+    return;
+  }
+
+  for (let i = 0; i < lifeform.stakedTreasureIds.length; i++) {
+    const tokenId = lifeform.stakedTreasureIds[i];
+    const treasureStat = getOrCreateTreasureStat(tokenId);
+    const originalAmount = lifeform.stakedTreasureAmounts[i];
+    const unstakingIndex = params._unstakingTreasureIds.indexOf(tokenId);
+    const brokenAmount =
+      unstakingIndex >= 0
+        ? originalAmount.minus(params._unstakingTreasureAmounts[unstakingIndex])
+        : originalAmount;
+    treasureStat.unstaked = treasureStat.unstaked.plus(originalAmount);
+    treasureStat.broken = treasureStat.broken.plus(brokenAmount);
+    treasureStat.save();
+
+    globalStat.treasuresUnstaked =
+      globalStat.treasuresUnstaked.plus(originalAmount);
+    globalStat.treasuresBroken = globalStat.treasuresBroken.plus(brokenAmount);
+  }
+
+  // Clear Lifeform's staked treasures
+  lifeform.stakedTreasureIds = [];
+  lifeform.stakedTreasureAmounts = [];
+  lifeform.save();
+
+  globalStat.save();
+}

--- a/subgraphs/seed-of-life-stats/template.yaml
+++ b/subgraphs/seed-of-life-stats/template.yaml
@@ -1,0 +1,54 @@
+specVersion: 0.0.4
+schema:
+  file: ./schema.graphql
+dataSources:
+  - name: Randomizer
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      address: "{{ randomizer_address }}"
+      abi: Randomizer
+      startBlock: {{ randomizer_seed_of_life_start_block }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Random
+        - Seeded
+        - Lifeform
+        - ClaimLifeform
+      abis:
+        - name: Randomizer
+          file: ../../node_modules/@treasure/subgraph-abis/src/Randomizer.json
+        - name: SeedEvolution
+          file: ../../node_modules/@treasure/subgraph-abis/src/SeedEvolution.json
+      eventHandlers:
+        - event: RandomRequest(indexed uint256,indexed uint256)
+          handler: handleRandomRequest
+        - event: RandomSeeded(indexed uint256)
+          handler: handleRandomSeeded
+      file: ./src/mappings/randomizer.ts
+  - name: SeedEvolution
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      address: "{{ seed_evolution_address }}"
+      abi: SeedEvolution
+      startBlock: {{ seed_evolution_start_block }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Lifeform
+        - Token
+      abis:
+        - name: SeedEvolution
+          file: ../../node_modules/@treasure/subgraph-abis/src/SeedEvolution.json
+      eventHandlers:
+        - event: LifeformCreated(indexed uint256,(uint256,uint256,address,uint8,uint8,uint8,uint256,uint256,uint256[],uint256[]))
+          handler: handleLifeformCreated
+        - event: FinishedUnstakingTreasure(address,uint256[],uint256[])
+          handler: handleFinishedUnstakingTreasure
+      file: ./src/mappings/seed-evolution.ts

--- a/subgraphs/seed-of-life-stats/tests/seed-evolution/seed-evolution.test.ts
+++ b/subgraphs/seed-of-life-stats/tests/seed-evolution/seed-evolution.test.ts
@@ -1,0 +1,115 @@
+import { assert, clearStore, test } from "matchstick-as";
+
+import { TREASURE_STAT_ENTITY_TYPE } from "../../../bridgeworld-stats/tests/utils";
+import {
+  handleFinishedUnstakingTreasure,
+  handleLifeformCreated,
+} from "../../src/mappings/seed-evolution";
+import {
+  DONKEY_TOKEN_ID,
+  GLOBAL_STAT_ENTITY_TYPE,
+  GOLD_COIN_TOKEN_ID,
+  LIFEFORM_ENTITY_TYPE,
+  toHexString,
+} from "../utils";
+import {
+  createFinishedUnstakingTreasureEvent,
+  createLifeformCreatedEvent,
+} from "./utils";
+
+test("unstaked treasures are tracked", () => {
+  clearStore();
+
+  // Create Lifeform
+  handleLifeformCreated(
+    createLifeformCreatedEvent(
+      1,
+      0,
+      1,
+      2,
+      [GOLD_COIN_TOKEN_ID, DONKEY_TOKEN_ID],
+      [6, 2]
+    )
+  );
+
+  // Lifeform should tracked staked treasures
+  const lifeformId = "0x1";
+  assert.fieldEquals(
+    LIFEFORM_ENTITY_TYPE,
+    lifeformId,
+    "stakedTreasureIds",
+    "[92, 114]"
+  );
+  assert.fieldEquals(
+    LIFEFORM_ENTITY_TYPE,
+    lifeformId,
+    "stakedTreasureAmounts",
+    "[6, 2]"
+  );
+
+  // Treasure stats should track staking
+  assert.fieldEquals(
+    TREASURE_STAT_ENTITY_TYPE,
+    toHexString(GOLD_COIN_TOKEN_ID),
+    "staked",
+    "6"
+  );
+  assert.fieldEquals(
+    TREASURE_STAT_ENTITY_TYPE,
+    toHexString(DONKEY_TOKEN_ID),
+    "staked",
+    "2"
+  );
+
+  // Global stats should track staking
+  assert.fieldEquals(GLOBAL_STAT_ENTITY_TYPE, "only", "treasuresStaked", "8");
+
+  // Unstake treasures
+  handleFinishedUnstakingTreasure(
+    createFinishedUnstakingTreasureEvent([92], [5])
+  );
+
+  // Lifeform should not have staked treasures
+  assert.fieldEquals(
+    LIFEFORM_ENTITY_TYPE,
+    lifeformId,
+    "stakedTreasureIds",
+    "[]"
+  );
+  assert.fieldEquals(
+    LIFEFORM_ENTITY_TYPE,
+    lifeformId,
+    "stakedTreasureAmounts",
+    "[]"
+  );
+
+  // Treasure stats should track unstaking and breaking
+  assert.fieldEquals(
+    TREASURE_STAT_ENTITY_TYPE,
+    toHexString(GOLD_COIN_TOKEN_ID),
+    "unstaked",
+    "6"
+  );
+  assert.fieldEquals(
+    TREASURE_STAT_ENTITY_TYPE,
+    toHexString(GOLD_COIN_TOKEN_ID),
+    "broken",
+    "1"
+  );
+  assert.fieldEquals(
+    TREASURE_STAT_ENTITY_TYPE,
+    toHexString(DONKEY_TOKEN_ID),
+    "unstaked",
+    "2"
+  );
+  assert.fieldEquals(
+    TREASURE_STAT_ENTITY_TYPE,
+    toHexString(DONKEY_TOKEN_ID),
+    "broken",
+    "2"
+  );
+
+  // Global stats should track unstaking and breaking
+  assert.fieldEquals(GLOBAL_STAT_ENTITY_TYPE, "only", "treasuresUnstaked", "8");
+  assert.fieldEquals(GLOBAL_STAT_ENTITY_TYPE, "only", "treasuresBroken", "3");
+});

--- a/subgraphs/seed-of-life-stats/tests/seed-evolution/utils.ts
+++ b/subgraphs/seed-of-life-stats/tests/seed-evolution/utils.ts
@@ -1,0 +1,67 @@
+import { newMockEvent } from "matchstick-as";
+
+import { Address, ethereum } from "@graphprotocol/graph-ts";
+
+import {
+  FinishedUnstakingTreasure,
+  LifeformCreated,
+} from "../../generated/SeedEvolution/SeedEvolution";
+import { USER_ADDRESS } from "../utils";
+
+export function createLifeformCreatedEvent(
+  lifeformId: i32,
+  firstRealm: i32,
+  secondRealm: i32,
+  path: i32,
+  stakedTreasureIds: i32[] = [],
+  stakedTreasureAmounts: i32[] = [],
+  owner: string = USER_ADDRESS,
+  requestId: i32 = 1
+): LifeformCreated {
+  const event = changetype<LifeformCreated>(newMockEvent());
+  event.parameters = [
+    new ethereum.EventParam("_lifeformId", ethereum.Value.fromI32(lifeformId)),
+    new ethereum.EventParam(
+      "_evolutionInfo",
+      ethereum.Value.fromTuple(
+        changetype<ethereum.Tuple>([
+          ethereum.Value.fromI32(0), // startTime
+          ethereum.Value.fromI32(requestId),
+          ethereum.Value.fromAddress(Address.fromString(owner)),
+          ethereum.Value.fromI32(path),
+          ethereum.Value.fromI32(firstRealm),
+          ethereum.Value.fromI32(secondRealm),
+          ethereum.Value.fromI32(0), // treasureBoost
+          ethereum.Value.fromI32(0), // unstakingRequestId
+          ethereum.Value.fromI32Array(stakedTreasureIds),
+          ethereum.Value.fromI32Array(stakedTreasureAmounts),
+        ])
+      )
+    ),
+  ];
+
+  return event;
+}
+
+export function createFinishedUnstakingTreasureEvent(
+  unstakingTreasureIds: i32[] = [],
+  unstakingTreasureAmounts: i32[] = [],
+  owner: string = USER_ADDRESS
+): FinishedUnstakingTreasure {
+  const event = changetype<FinishedUnstakingTreasure>(newMockEvent());
+  event.parameters = [
+    new ethereum.EventParam(
+      "_owner",
+      ethereum.Value.fromAddress(Address.fromString(owner))
+    ),
+    new ethereum.EventParam(
+      "_unstakingTreasureIds",
+      ethereum.Value.fromI32Array(unstakingTreasureIds)
+    ),
+    new ethereum.EventParam(
+      "_unstakingTreasureAmounts",
+      ethereum.Value.fromI32Array(unstakingTreasureAmounts)
+    ),
+  ];
+  return event;
+}

--- a/subgraphs/seed-of-life-stats/tests/utils.ts
+++ b/subgraphs/seed-of-life-stats/tests/utils.ts
@@ -1,0 +1,10 @@
+export const GLOBAL_STAT_ENTITY_TYPE = "GlobalStat";
+export const LIFEFORM_ENTITY_TYPE = "_Lifeform";
+export const TREASURE_STATE_ENTITY_TYPE = "TreasureStat";
+
+export const USER_ADDRESS = "0x461950b159366edcd2bcbee8126d973ac49238e0";
+
+export const GOLD_COIN_TOKEN_ID = 92;
+export const DONKEY_TOKEN_ID = 114;
+
+export const toHexString = (value: i32): string => `0x${value.toString(16)}`;


### PR DESCRIPTION
# Seed of Life subgraph
We've discovered a mismatch in the ABI and contract code for Seed of Life Evolution:

ABI params say broken treasures: [https://github.com/TreasureProject/sol-contracts/blob/a081cd307386e6e1f5c4d8ed947b[…]f14a8/contracts/seedoflife/seedevolution/SeedEvolutionState.sol](https://github.com/TreasureProject/sol-contracts/blob/a081cd307386e6e1f5c4d8ed947b8339fcef14a8/contracts/seedoflife/seedevolution/SeedEvolutionState.sol#L24)

Event passes unstaking treasures: https://github.com/TreasureProject/sol-contracts/blob/main/contracts/seedoflife/seedevolution/SeedEvolution.sol#L293

I've updated the ABI in the subgraph repo to reflect the `_unstakingTreasureIds` that actually get passed into this function and refactored the processing of broken tokens

# Seed of Life Stats subgraph
Added new Seed of Life Stats subgraph, already deployed here: https://thegraph.com/hosted-service/subgraph/treasureproject/seed-of-life-stats-dev. This subgraph is designed to power stats on Treasure Tools: https://treasure.tools/data/life