### PR TITLE
fix unit tests by forcing matchstick 0.4.2

### DIFF
--- a/subgraphs/bridgeworld-stats/package.json
+++ b/subgraphs/bridgeworld-stats/package.json
@@ -9,6 +9,6 @@
     "deploy:prod": "graph deploy --product hosted-service treasureproject/bridgeworld-stats",
     "prepare:dev": "yarn --cwd ../../packages/constants prepare:arbitrum-testnet && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:prod": "yarn --cwd ../../packages/constants prepare:arbitrum && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "test": "graph test"
+    "test": "graph test -v 0.4.2"
   }
 }

--- a/subgraphs/marketplace/package.json
+++ b/subgraphs/marketplace/package.json
@@ -10,6 +10,6 @@
     "deploy:prod": "graph deploy --product hosted-service treasureproject/marketplace",
     "prepare:dev": "yarn --cwd ../../packages/constants prepare:arbitrum-testnet && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:prod": "yarn --cwd ../../packages/constants prepare:arbitrum && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "test": "graph test"
+    "test": "graph test -v 0.4.2"
   }
 }

--- a/subgraphs/smolverse/package.json
+++ b/subgraphs/smolverse/package.json
@@ -9,6 +9,6 @@
     "deploy:prod": "graph deploy --product hosted-service treasureproject/smolverse",
     "prepare:dev": "yarn --cwd ../../packages/constants prepare:arbitrum-testnet && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum-testnet.json template.yaml > subgraph.yaml",
     "prepare:prod": "yarn --cwd ../../packages/constants prepare:arbitrum && mustache ../../node_modules/@treasure/subgraph-config/src/arbitrum.json template.yaml > subgraph.yaml",
-    "test": "graph test"
+    "test": "graph test -v 0.4.2"
   }
 }


### PR DESCRIPTION
Fixes unit tests by forcing a few subgraphs to use Matchstick v0.4.2. I believe there's a bug in v0.4.3 that fails on non-required `derivedFrom` relations, but haven't dug deeper into it yet