### PR TITLE
fix token generation field for legions

### DIFF
--- a/subgraphs/bridgeworld/src/mappings/legion.ts
+++ b/subgraphs/bridgeworld/src/mappings/legion.ts
@@ -254,6 +254,7 @@ export function handleLegionCreated(event: LegionCreated): void {
   token.image = `${LEGION_IPFS}/${metadata.rarity}%20${metadata.role}.gif`;
   token.name = `${metadata.type} ${metadata.rarity}`;
   token.metadata = metadata.id;
+  token.generation = params._generation;
   token.rarity = metadata.rarity.replace("Recruit", "None");
 
   if (metadata.type == "Recruit") {

--- a/subgraphs/bridgeworld/tests/legion.test.ts
+++ b/subgraphs/bridgeworld/tests/legion.test.ts
@@ -66,6 +66,7 @@ test("legion metadata is correct for pilgrimaged riverman", () => {
     "ipfs://QmRqosGZZ6icx6uSDjLuFFMJiWDefZAiAZdpJdBK9BP5S4/Riverman%201.png"
   );
   assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "name", "Genesis Special");
+  assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "generation", "0");
   assert.fieldEquals(TOKEN_ENTITY_TYPE, id, "rarity", "Special");
 
   const metadata = `${id}-metadata`;


### PR DESCRIPTION
Fixes #117 

- Fills `generation` field for `Token` entities of category `Legion`