### PR TITLE
[seed-of-life-stats] add realm combo stats

### DIFF
--- a/subgraphs/seed-of-life-stats/schema.graphql
+++ b/subgraphs/seed-of-life-stats/schema.graphql
@@ -69,6 +69,16 @@ type RealmStat @entity {
   secondRealmCount: BigInt!
 }
 
+type RealmComboStat @entity {
+  id: ID!
+
+  firstRealm: LifeformRealm!
+  secondRealm: LifeformRealm!
+
+  "Number of Lifeforms with this realm combination"
+  lifeformTotal: BigInt!
+}
+
 type PathStat @entity {
   id: ID!
 

--- a/subgraphs/seed-of-life-stats/src/helpers/stat.ts
+++ b/subgraphs/seed-of-life-stats/src/helpers/stat.ts
@@ -4,6 +4,7 @@ import {
   ClassStat,
   GlobalStat,
   PathStat,
+  RealmComboStat,
   RealmStat,
   TreasureStat,
 } from "../../generated/schema";
@@ -15,6 +16,22 @@ export const getOrCreateRealmStat = (realm: string): RealmStat => {
   if (!stat) {
     stat = new RealmStat(id);
     stat.realm = realm;
+    stat.save();
+  }
+
+  return stat;
+};
+
+export const getOrCreateRealmComboStat = (
+  firstRealm: string,
+  secondRealm: string
+): RealmComboStat => {
+  const id = `${firstRealm}-${secondRealm}`;
+  let stat = RealmComboStat.load(id);
+  if (!stat) {
+    stat = new RealmComboStat(id);
+    stat.firstRealm = firstRealm;
+    stat.secondRealm = secondRealm;
     stat.save();
   }
 

--- a/subgraphs/seed-of-life-stats/src/mappings/seed-evolution.ts
+++ b/subgraphs/seed-of-life-stats/src/mappings/seed-evolution.ts
@@ -17,6 +17,7 @@ import { getRealmByIndex } from "../helpers/realm";
 import {
   getOrCreateGlobalStat,
   getOrCreatePathStat,
+  getOrCreateRealmComboStat,
   getOrCreateRealmStat,
   getOrCreateTreasureStat,
 } from "../helpers/stat";
@@ -63,6 +64,10 @@ export function handleLifeformCreated(event: LifeformCreated): void {
   secondRealmStat.secondRealmCount =
     secondRealmStat.secondRealmCount.plus(ONE_BI);
   secondRealmStat.save();
+
+  const realmComboStat = getOrCreateRealmComboStat(firstRealm, secondRealm);
+  realmComboStat.lifeformTotal = realmComboStat.lifeformTotal.plus(ONE_BI);
+  realmComboStat.save();
 
   // Increment path stats
   const pathStat = getOrCreatePathStat(path);


### PR DESCRIPTION
- Adds new RealmComboStat entity to track stats for combinations of first and second realm