### PR TITLE
[metadata] force refresh Lost Donkeys metadata

### DIFF
--- a/subgraphs/metadata/src/helpers/json.ts
+++ b/subgraphs/metadata/src/helpers/json.ts
@@ -29,7 +29,8 @@ export function getIpfsJson(path: string, retries: i32 = 0): JSON | null {
   const normalizedPath = path
     .replace("ipfs://", "")
     .replace("https://treasure-marketplace.mypinata.cloud/ipfs/", "")
-    .replace("https://treasuredao.mypinata.cloud/ipfs/", "");
+    .replace("https://treasuredao.mypinata.cloud/ipfs/", "")
+    .replace("https://thelostdonkeys.mypinata.cloud/ipfs/", "");
 
   const data = ipfs.cat(normalizedPath);
 

--- a/subgraphs/metadata/src/mapping.ts
+++ b/subgraphs/metadata/src/mapping.ts
@@ -4,7 +4,7 @@ import { Collection, Token } from "../generated/schema";
 import { MISSING_METADATA_UPDATE_INTERVAL } from "./helpers/constants";
 import { getOrCreateCollection, getOrCreateToken } from "./helpers/models";
 
-const TOKEN_REFETCH_COUNT = 100;
+const TOKEN_REFETCH_COUNT = 10000;
 
 export class TransferEvent {
   constructor(
@@ -55,10 +55,12 @@ export function handleTransfer(
 
     for (let index = 0; index < tokenIds.length; index++) {
       const token = Token.load(tokenIds[index]);
-
-      if (token) {
-        fetchTokenMetadata(collection, token, timestamp);
+      if (!token) {
+        log.warning("[fetch-metadata] token not found: {}", [tokenIds[index]]);
+        continue;
       }
+
+      fetchTokenMetadata(collection, token, timestamp);
     }
 
     // Update cron job's last run time

--- a/subgraphs/metadata/src/mapping.ts
+++ b/subgraphs/metadata/src/mapping.ts
@@ -4,7 +4,7 @@ import { Collection, Token } from "../generated/schema";
 import { MISSING_METADATA_UPDATE_INTERVAL } from "./helpers/constants";
 import { getOrCreateCollection, getOrCreateToken } from "./helpers/models";
 
-const TOKEN_REFETCH_COUNT = 10000;
+const TOKEN_REFETCH_COUNT = 100;
 
 export class TransferEvent {
   constructor(

--- a/subgraphs/metadata/src/mappings/lost-donkeys.ts
+++ b/subgraphs/metadata/src/mappings/lost-donkeys.ts
@@ -4,6 +4,7 @@ import { ERC721, Transfer } from "../../generated/Lost Donkeys/ERC721";
 import { Collection, Token } from "../../generated/schema";
 import { getIpfsJson } from "../helpers/json";
 import { updateTokenMetadata } from "../helpers/metadata";
+import { getOrCreateCollection } from "../helpers/models";
 import { isMint } from "../helpers/utils";
 import * as common from "../mapping";
 
@@ -39,6 +40,17 @@ export function handleTransfer(event: Transfer): void {
     isMint(params.from),
     event.block.timestamp
   );
+
+  if (event.block.number.toString() == "12575754") {
+    const tokenIds: string[] = [];
+    const collection = getOrCreateCollection(event.address);
+    for (let index = 0; index <= 8055; index++) {
+      tokenIds.push(`${collection.id}-0x${index.toString(16)}`);
+    }
+
+    collection._missingMetadataTokens = tokenIds;
+    collection.save();
+  }
 
   common.handleTransfer(transfer, fetchTokenMetadata);
 }


### PR DESCRIPTION
Forces a refresh on all Lost Donkeys metadata after block 12575754, a transfer event close to when the team launched the metadata changes.