### PR TITLE
[bridgeworld] track stasis hits when auto-progressing

### DIFF
--- a/subgraphs/bridgeworld/src/mappings/randomizer.ts
+++ b/subgraphs/bridgeworld/src/mappings/randomizer.ts
@@ -117,11 +117,13 @@ export function handleRandomSeeded(event: RandomSeeded): void {
             ]);
           }
 
-          if (quest.part === 2 && quest.stasisHitCount > 0) {
-            quest.hadStasisPart2 = true;
-          }
-          if (quest.part === 3 && quest.stasisHitCount > 0) {
-            quest.hadStasisPart3 = true;
+          if (quest.stasisHitCount > 0) {
+            if (quest.part === 2) {
+              quest.hadStasisPart2 = true;
+            } else if (quest.part === 3) {
+              quest.hadStasisPart2 = quest.stasisHitCount >= 2;
+              quest.hadStasisPart3 = true;
+            }
           }
 
           quest.save();

--- a/subgraphs/bridgeworld/src/mappings/randomizer.ts
+++ b/subgraphs/bridgeworld/src/mappings/randomizer.ts
@@ -121,7 +121,8 @@ export function handleRandomSeeded(event: RandomSeeded): void {
             if (quest.part === 2) {
               quest.hadStasisPart2 = true;
             } else if (quest.part === 3) {
-              quest.hadStasisPart2 = quest.stasisHitCount >= 2;
+              quest.hadStasisPart2 =
+                quest.hadStasisPart2 || quest.stasisHitCount >= 2;
               quest.hadStasisPart3 = true;
             }
           }


### PR DESCRIPTION
Updates the `hadStasisPartX` flags to track stasis hits when auto-progressing to the third part of a quest