### PR TITLE
add block number to mini craft because timestamp is not unique per group

### DIFF
--- a/subgraphs/bridgeworld/schema.graphql
+++ b/subgraphs/bridgeworld/schema.graphql
@@ -190,6 +190,7 @@ type Craft @entity {
 type MiniCraft @entity {
   id: ID!
 
+  blockNumber: BigInt!
   timestamp: BigInt!
   tier: Int!
   token: Token!

--- a/subgraphs/bridgeworld/src/mappings/mini-crafting.ts
+++ b/subgraphs/bridgeworld/src/mappings/mini-crafting.ts
@@ -5,7 +5,6 @@ import { LegionInfo, MiniCraft, Outcome } from "../../generated/schema";
 import { getAddressId } from "../helpers";
 
 export function handleCraftingFinished(event: CraftingFinished): void {
-  const timestamp = event.block.timestamp;
   const params = event.params;
   const tokenId = params._legionId;
   const xpGained = params._cpGained;
@@ -13,7 +12,8 @@ export function handleCraftingFinished(event: CraftingFinished): void {
   // Save mini craft details
   const miniCraftId = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
   const miniCraft = new MiniCraft(miniCraftId);
-  miniCraft.timestamp = timestamp;
+  miniCraft.blockNumber = event.block.number;
+  miniCraft.timestamp = event.block.timestamp;
   miniCraft.tier = params._tier;
   miniCraft.token = getAddressId(LEGION_ADDRESS, tokenId);
   miniCraft.user = params._user.toHexString();


### PR DESCRIPTION
Adds `blockNumber` field to the `MiniCraft` entity so we can group batches of mini crafts on the front-end. `timestamp` is not unique per batch because Arbitrum applies the L1 block timestamp to the transaction, and multiple blocks/batches can have the same exact timestamp