### PR TITLE
add handlers for new questing xp gained events

### DIFF
--- a/packages/abis/src/AdvancedQuesting.json
+++ b/packages/abis/src/AdvancedQuesting.json
@@ -5,116 +5,6 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "previousAdmin",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
-    ],
-    "name": "AdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "implementation",
-        "type": "address"
-      }
-    ],
-    "name": "Upgraded",
-    "type": "event"
-  },
-  {
-    "stateMutability": "payable",
-    "type": "fallback"
-  },
-  {
-    "inputs": [],
-    "name": "admin",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
-    ],
-    "name": "changeAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "implementation",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      }
-    ],
-    "name": "upgradeTo",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "upgradeToAndCall",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "stateMutability": "payable",
-    "type": "receive"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
         "name": "_owner",
         "type": "address"
       },
@@ -276,6 +166,25 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "uint8",
+        "name": "_endingPart",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_qpGained",
+        "type": "uint256"
+      }
+    ],
+    "name": "QPForEndingPart",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "address",
         "name": "_owner",
         "type": "address"
@@ -350,20 +259,83 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_legionId",
-        "type": "uint256"
-      }
-    ],
-    "name": "advanceToPartForLegion",
-    "outputs": [
+        "internalType": "string",
+        "name": "_zoneName",
+        "type": "string"
+      },
       {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "zoneStartTime",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum TreasureCategory",
+            "name": "categoryBoost1",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum TreasureCategory",
+            "name": "categoryBoost2",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum Constellation",
+            "name": "constellation1",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum Constellation",
+            "name": "constellation2",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "zonePartLength",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "stasisLength",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint8",
+                "name": "stasisBaseRate",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint8",
+                "name": "questingLevelRequirement",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint8",
+                "name": "questingXpGained",
+                "type": "uint8"
+              },
+              {
+                "internalType": "bool",
+                "name": "playTreasureTriad",
+                "type": "bool"
+              }
+            ],
+            "internalType": "struct ZonePart[]",
+            "name": "parts",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct ZoneInfo",
+        "name": "_zone",
+        "type": "tuple"
       }
     ],
-    "stateMutability": "view",
+    "name": "addZone",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -374,6 +346,19 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chanceUniversalLock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -408,20 +393,41 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_legionId",
-        "type": "uint256"
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "legionId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "zone",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "treasureIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "treasureAmounts",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct EmergencyEndQuestingParams[]",
+        "name": "_endParams",
+        "type": "tuple[]"
       }
     ],
-    "name": "currentPartForLegion",
-    "outputs": [
-      {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "view",
+    "name": "emergencyEndQuesting",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -430,6 +436,11 @@
         "internalType": "uint256[]",
         "name": "_legionIds",
         "type": "uint256[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "_restartQuesting",
+        "type": "bool[]"
       }
     ],
     "name": "endQuesting",
@@ -456,6 +467,25 @@
         "internalType": "uint8",
         "name": "",
         "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "endingPartToQPGained",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -565,25 +595,6 @@
       }
     ],
     "name": "lengthForPartOfZone",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "_zoneName",
-        "type": "string"
-      }
-    ],
-    "name": "numberOfPartsInZone",
     "outputs": [
       {
         "internalType": "uint256",
@@ -733,6 +744,53 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "legionId",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint8",
+                "name": "x",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint8",
+                "name": "y",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "treasureId",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct UserMove[]",
+            "name": "playerMoves",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "bool",
+            "name": "restartQuestIfPossible",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct PlayTreasureTriadParams[]",
+        "name": "_params",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "playTreasureTriad",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "questing",
     "outputs": [
@@ -794,6 +852,19 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "_chanceUniversalLock",
+        "type": "uint256"
+      }
+    ],
+    "name": "setChanceUniversalLock",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "_randomizerAddress",
         "type": "address"
@@ -847,12 +918,50 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "endingPart",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint248",
+            "name": "qpGained",
+            "type": "uint248"
+          }
+        ],
+        "internalType": "struct EndingPartParams[]",
+        "name": "_endingPartParams",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setEndingPartToQPGained",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bool",
         "name": "_shouldPause",
         "type": "bool"
       }
     ],
     "name": "setPause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_stasisLengthForCorruptedCard",
+        "type": "uint256"
+      }
+    ],
+    "name": "setStasisLengthForCorruptedCard",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -895,6 +1004,19 @@
     "name": "startAdvancedQuesting",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stasisLengthForCorruptedCard",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1008,6 +1130,34 @@
     "inputs": [
       {
         "internalType": "string",
+        "name": "_zoneName",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_partIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_rewardIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8[7]",
+        "name": "_questLevelBoosts",
+        "type": "uint8[7]"
+      }
+    ],
+    "name": "updateQuestLevelBoosts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
         "name": "",
         "type": "string"
       }
@@ -1046,22 +1196,35 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "initialLogic",
-        "type": "address"
+        "internalType": "string",
+        "name": "",
+        "type": "string"
       },
       {
-        "internalType": "address",
-        "name": "initialAdmin",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       },
       {
-        "internalType": "bytes",
-        "name": "_data",
-        "type": "bytes"
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
-    "stateMutability": "payable",
-    "type": "constructor"
+    "name": "zoneNameToPartIndexToRewardIndexToQuestBoosts",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/packages/abis/src/Questing.json
+++ b/packages/abis/src/Questing.json
@@ -1,1 +1,1365 @@
-[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"account","type":"address"}],"name":"Paused","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"_owner","type":"address"},{"indexed":true,"internalType":"uint256","name":"_tokenId","type":"uint256"}],"name":"QuestFinished","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"_owner","type":"address"},{"indexed":true,"internalType":"uint256","name":"_tokenId","type":"uint256"},{"components":[{"internalType":"uint8","name":"starlightAmount","type":"uint8"},{"internalType":"uint8","name":"crystalShardAmount","type":"uint8"},{"internalType":"uint8","name":"universalLockAmount","type":"uint8"},{"internalType":"uint256","name":"treasureId","type":"uint256"}],"indexed":false,"internalType":"struct QuestReward","name":"_reward","type":"tuple"}],"name":"QuestRevealed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"_owner","type":"address"},{"indexed":true,"internalType":"uint256","name":"_tokenId","type":"uint256"},{"indexed":true,"internalType":"uint256","name":"_requestId","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"_finishTime","type":"uint256"},{"indexed":false,"internalType":"enum QuestDifficulty","name":"_difficulty","type":"uint8"}],"name":"QuestStarted","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"account","type":"address"}],"name":"Unpaused","type":"event"},{"inputs":[{"internalType":"address","name":"_address","type":"address"}],"name":"addAdmin","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address[]","name":"_addresses","type":"address[]"}],"name":"addAdmins","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"consumable","outputs":[{"internalType":"contract IConsumable","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"}],"name":"difficultyToLPNeeded","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"}],"name":"difficultyToLevelUnlocked","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"}],"name":"difficultyToQuestLength","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"}],"name":"difficultyToShardAmount","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"}],"name":"difficultyToStarlightAmount","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"difficultyToTierOdds","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256[]","name":"_tokenIds","type":"uint256[]"}],"name":"finishTokenQuests","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"initialize","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_address","type":"address"}],"name":"isAdmin","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"_tokenId","type":"uint256"}],"name":"isQuestReadyToReveal","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"legion","outputs":[{"internalType":"contract ILegion","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"legionMetadataStore","outputs":[{"internalType":"contract ILegionMetadataStore","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"levelToQPGainedPerQuest","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"levelToQPNeeded","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"lp","outputs":[{"internalType":"contract ILP","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"maxQuestLevel","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"uint256[]","name":"","type":"uint256[]"},{"internalType":"uint256[]","name":"","type":"uint256[]"},{"internalType":"bytes","name":"","type":"bytes"}],"name":"onERC1155BatchReceived","outputs":[{"internalType":"bytes4","name":"","type":"bytes4"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"bytes","name":"","type":"bytes"}],"name":"onERC1155Received","outputs":[{"internalType":"bytes4","name":"","type":"bytes4"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"bytes","name":"","type":"bytes"}],"name":"onERC721Received","outputs":[{"internalType":"bytes4","name":"","type":"bytes4"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"paused","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"randomizer","outputs":[{"internalType":"contract IRandomizer","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"recruitCrystalShardsOdds","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"recruitNumberOfCrystalShards","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"recruitNumberOfStarlight","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"recruitUniversalLockOdds","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"_address","type":"address"}],"name":"removeAdmin","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address[]","name":"_addresses","type":"address[]"}],"name":"removeAdmins","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256[]","name":"_tokenIds","type":"uint256[]"},{"internalType":"enum QuestDifficulty[]","name":"_difficulties","type":"uint8[]"},{"internalType":"uint256[]","name":"_questLoops","type":"uint256[]"}],"name":"restartTokenQuests","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256[]","name":"_tokenIds","type":"uint256[]"}],"name":"revealTokensQuests","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256[]","name":"_availableLoops","type":"uint256[]"}],"name":"setAutoQuestLoops","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_randomizerAddress","type":"address"},{"internalType":"address","name":"_treasureAddress","type":"address"},{"internalType":"address","name":"_legionAddress","type":"address"},{"internalType":"address","name":"_treasureMetadataStoreAddress","type":"address"},{"internalType":"address","name":"_legionMetadataStoreAddress","type":"address"},{"internalType":"address","name":"_lpAddress","type":"address"},{"internalType":"address","name":"_consumableAddress","type":"address"},{"internalType":"address","name":"_treasuryAddress","type":"address"}],"name":"setContracts","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint8[3]","name":"_shardAmounts","type":"uint8[3]"},{"internalType":"uint8[3]","name":"_starlightAmounts","type":"uint8[3]"}],"name":"setGuaranteedDropAmounts","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256[3]","name":"_lpNeeded","type":"uint256[3]"}],"name":"setLPNeeded","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint8","name":"_easyLevel","type":"uint8"},{"internalType":"uint8","name":"_mediumLevel","type":"uint8"},{"internalType":"uint8","name":"_hardLevel","type":"uint8"}],"name":"setLevelDifficultyUnlocks","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint8","name":"_maxQuestLevel","type":"uint8"},{"internalType":"uint256[]","name":"_qpNeededForEachLevel","type":"uint256[]"},{"internalType":"uint256[]","name":"_qpGainedAtEachLevel","type":"uint256[]"}],"name":"setLevelSteps","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bool","name":"_shouldPause","type":"bool"}],"name":"setPause","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"_easyLength","type":"uint256"},{"internalType":"uint256","name":"_mediumLength","type":"uint256"},{"internalType":"uint256","name":"_hardLength","type":"uint256"}],"name":"setQuestLengths","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint8","name":"_recruitNumberOfStarlight","type":"uint8"},{"internalType":"uint8","name":"_recruitNumberOfCrystalShards","type":"uint8"},{"internalType":"uint256","name":"_recruitCrystalShardsOdds","type":"uint256"},{"internalType":"uint256","name":"_recruitUniversalLockOdds","type":"uint256"}],"name":"setRecruitSettings","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"_treasureDropOdds","type":"uint256"},{"internalType":"uint256","name":"_universalLockDropOdds","type":"uint256"},{"internalType":"uint256","name":"_starlightId","type":"uint256"},{"internalType":"uint256","name":"_shardId","type":"uint256"},{"internalType":"uint256","name":"_universalLockId","type":"uint256"}],"name":"setTreasureSettings","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"shardId","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"starlightId","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256[]","name":"_tokenIds","type":"uint256[]"},{"internalType":"enum QuestDifficulty[]","name":"_difficulties","type":"uint8[]"},{"internalType":"uint256[]","name":"_questLoops","type":"uint256[]"}],"name":"startQuests","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes4","name":"interfaceId","type":"bytes4"}],"name":"supportsInterface","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tokenIdToLPStaked","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tokenIdToNumberLoops","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tokenIdToQP","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tokenIdToQuestDifficulty","outputs":[{"internalType":"enum QuestDifficulty","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tokenIdToQuestStartTime","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tokenIdToRequestId","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"treasure","outputs":[{"internalType":"contract ITreasure","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"treasureDropOdds","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"treasureMetadataStore","outputs":[{"internalType":"contract ITreasureMetadataStore","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"treasury","outputs":[{"internalType":"contract ITreasury","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"universalLockDropOdds","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"universalLockId","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "_questLevel",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_qpFinal",
+        "type": "uint256"
+      }
+    ],
+    "name": "QPGained",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "QuestFinished",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "starlightAmount",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint8",
+            "name": "crystalShardAmount",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint8",
+            "name": "universalLockAmount",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "treasureId",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct QuestReward",
+        "name": "_reward",
+        "type": "tuple"
+      }
+    ],
+    "name": "QuestRevealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_requestId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_finishTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum QuestDifficulty",
+        "name": "_difficulty",
+        "type": "uint8"
+      }
+    ],
+    "name": "QuestStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "addAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_addresses",
+        "type": "address[]"
+      }
+    ],
+    "name": "addAdmins",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "areContractsSet",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "consumable",
+    "outputs": [
+      {
+        "internalType": "contract IConsumable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "difficultyToLPNeeded",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "difficultyToLevelUnlocked",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "difficultyToQuestLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "difficultyToShardAmount",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "difficultyToStarlightAmount",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "difficultyToTierOdds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_tokenIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "finishTokenQuests",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "getStakedLegions",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "isAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isNonRecruitLegionPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "isQuestReadyToReveal",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "legion",
+    "outputs": [
+      {
+        "internalType": "contract ILegion",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "legionMetadataStore",
+    "outputs": [
+      {
+        "internalType": "contract ILegionMetadataStore",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "levelToQPGainedPerQuest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "levelToQPNeeded",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lp",
+    "outputs": [
+      {
+        "internalType": "contract ILP",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxQuestLevel",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_currentQuestLevel",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_qpGained",
+        "type": "uint256"
+      }
+    ],
+    "name": "processQPGainAndLevelUp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "randomizer",
+    "outputs": [
+      {
+        "internalType": "contract IRandomizer",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "recruitCrystalShardsOdds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "recruitNumberOfCrystalShards",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "recruitNumberOfStarlight",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "recruitUniversalLockOdds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "removeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_addresses",
+        "type": "address[]"
+      }
+    ],
+    "name": "removeAdmins",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "enum QuestDifficulty[]",
+        "name": "_difficulties",
+        "type": "uint8[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_questLoops",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "restartTokenQuests",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_tokenIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "revealTokensQuests",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_availableLoops",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "setAutoQuestLoops",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_randomizerAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasureAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_legionAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasureMetadataStoreAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_legionMetadataStoreAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_lpAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_consumableAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasuryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setContracts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8[3]",
+        "name": "_shardAmounts",
+        "type": "uint8[3]"
+      },
+      {
+        "internalType": "uint8[3]",
+        "name": "_starlightAmounts",
+        "type": "uint8[3]"
+      }
+    ],
+    "name": "setGuaranteedDropAmounts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isNonRecruitLegionPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsNonRecruitLegionPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[3]",
+        "name": "_lpNeeded",
+        "type": "uint256[3]"
+      }
+    ],
+    "name": "setLPNeeded",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_easyLevel",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_mediumLevel",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_hardLevel",
+        "type": "uint8"
+      }
+    ],
+    "name": "setLevelDifficultyUnlocks",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_maxQuestLevel",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_qpNeededForEachLevel",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_qpGainedAtEachLevel",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "setLevelSteps",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_shouldPause",
+        "type": "bool"
+      }
+    ],
+    "name": "setPause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_easyLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_mediumLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_hardLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "setQuestLengths",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_recruitNumberOfStarlight",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_recruitNumberOfCrystalShards",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_recruitCrystalShardsOdds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_recruitUniversalLockOdds",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRecruitSettings",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[5]",
+        "name": "_easyTierOdds",
+        "type": "uint256[5]"
+      },
+      {
+        "internalType": "uint256[5]",
+        "name": "_mediumTierOdds",
+        "type": "uint256[5]"
+      },
+      {
+        "internalType": "uint256[5]",
+        "name": "_hardTierOdds",
+        "type": "uint256[5]"
+      }
+    ],
+    "name": "setTierOddsForDifficulty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_treasureDropOdds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_universalLockDropOdds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_starlightId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_shardId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_universalLockId",
+        "type": "uint256"
+      }
+    ],
+    "name": "setTreasureSettings",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shardId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "starlightId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "enum QuestDifficulty[]",
+        "name": "_difficulties",
+        "type": "uint8[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_questLoops",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "startQuests",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdToLPStaked",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdToNumberLoops",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdToQP",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdToQuestDifficulty",
+    "outputs": [
+      {
+        "internalType": "enum QuestDifficulty",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdToQuestStartTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdToRequestId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasure",
+    "outputs": [
+      {
+        "internalType": "contract ITreasure",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasureDropOdds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasureMetadataStore",
+    "outputs": [
+      {
+        "internalType": "contract ITreasureMetadataStore",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasury",
+    "outputs": [
+      {
+        "internalType": "contract ITreasury",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "universalLockDropOdds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "universalLockId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/bridgeworld/schema.graphql
+++ b/subgraphs/bridgeworld/schema.graphql
@@ -48,6 +48,13 @@ interface Metadata {
   id: ID!
 }
 
+type _BlockConfig @entity {
+  id: ID!
+
+  "Block number at which the new Questing XP gained events were made available"
+  questingXpGainedBlockNumber: BigInt
+}
+
 type Constellation @entity {
   id: ID!
 

--- a/subgraphs/bridgeworld/src/helpers/config.ts
+++ b/subgraphs/bridgeworld/src/helpers/config.ts
@@ -1,0 +1,32 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
+import { _BlockConfig } from "../../generated/schema";
+
+export const getOrCreateBlockConfig = (): _BlockConfig => {
+  let blockConfig = _BlockConfig.load("only");
+  if (!blockConfig) {
+    blockConfig = new _BlockConfig("only");
+    blockConfig.save();
+  }
+
+  return blockConfig;
+};
+
+export const setQuestingXpGainedBlockNumberIfEmpty = (
+  blockNumber: BigInt
+): void => {
+  const blockConfig = getOrCreateBlockConfig();
+  if (!blockConfig.questingXpGainedBlockNumber) {
+    blockConfig.questingXpGainedBlockNumber = blockNumber;
+    blockConfig.save();
+  }
+};
+
+export const isQuestingXpGainedEnabled = (blockNumber: BigInt): boolean => {
+  const blockConfig = getOrCreateBlockConfig();
+  if (!blockConfig.questingXpGainedBlockNumber) {
+    return false;
+  }
+
+  return blockNumber.ge(blockConfig.questingXpGainedBlockNumber as BigInt);
+};

--- a/subgraphs/bridgeworld/src/helpers/legion.ts
+++ b/subgraphs/bridgeworld/src/helpers/legion.ts
@@ -1,7 +1,11 @@
 import { BigInt, log } from "@graphprotocol/graph-ts";
 
+import { LEGION_ADDRESS } from "@treasure/constants";
+
+import { LegionInfo } from "../../generated/schema";
 import { LEGION_PFP_IPFS } from "./constants";
 import { getName, getRole } from "./token-id";
+import { getAddressId } from "./utils";
 
 export const TYPE = ["Genesis", "Auxiliary", "Recruit"];
 
@@ -421,4 +425,16 @@ export const getLegacyGenesisLegionImage = (
     legacyTokenId,
     legacyTokenId
   );
+};
+
+export const getLegionMetadata = (tokenId: BigInt): LegionInfo => {
+  const metadata = LegionInfo.load(
+    `${getAddressId(LEGION_ADDRESS, tokenId)}-metadata`
+  );
+
+  if (!metadata) {
+    throw new Error(`Metadata not available: ${tokenId.toString()}`);
+  }
+
+  return metadata;
 };

--- a/subgraphs/bridgeworld/template.yaml
+++ b/subgraphs/bridgeworld/template.yaml
@@ -335,6 +335,8 @@ dataSources:
           handler: handleQuestRevealed
         - event: QuestFinished(indexed address,indexed uint256)
           handler: handleQuestFinished
+        - event: QPGained(uint256,uint8,uint256)
+          handler: handleQuestXpGained
       file: ./src/mappings/questing.ts
   - name: Questing Legacy
     kind: ethereum/contract
@@ -490,6 +492,8 @@ dataSources:
           handler: handleTreasureTriadPlayed
         - event: AdvancedQuestEnded(address,uint256,(uint256,uint256,uint256,uint256)[])
           handler: handleAdvancedQuestEnded
+        - event: QPForEndingPart(uint8,uint256)
+          handler: handleAdvancedQuestXpGained
       file: ./src/mappings/advanced-questing.ts
   - name: Treasure Triad
     kind: ethereum/contract

--- a/subgraphs/bridgeworld/tests/helpers/advanced-questing.ts
+++ b/subgraphs/bridgeworld/tests/helpers/advanced-questing.ts
@@ -69,7 +69,8 @@ export function simulateAdvancedQuest(
   requestId: i32 = 1,
   parts: i8 = 1,
   endQuest: boolean = true,
-  playTreasureTriad: boolean = false
+  playTreasureTriad: boolean = false,
+  blockNumber: i32 = 0
 ): void {
   handleAdvancedQuestStarted(
     createAdvancedQuestStartedEvent(user, legionId, requestId)
@@ -87,9 +88,12 @@ export function simulateAdvancedQuest(
 
   if (endQuest) {
     handleAdvancedQuestEnded(
-      createAdvancedQuestEndedEvent(user, legionId, [
-        new RewardParam(1, 1, 1, 1),
-      ])
+      createAdvancedQuestEndedEvent(
+        user,
+        legionId,
+        [new RewardParam(1, 1, 1, 1)],
+        blockNumber
+      )
     );
   }
 }
@@ -152,10 +156,14 @@ export function createAdvancedQuestContinuedEvent(
 export function createAdvancedQuestEndedEvent(
   user: string = USER_ADDRESS,
   legionId: i32 = 1,
-  rewards: RewardParam[] = []
+  rewards: RewardParam[] = [],
+  blockNumber: i32 = 0
 ): AdvancedQuestEnded {
   const newEvent = newMockEvent();
   newEvent.address = ADVANCED_QUESTING_ADDRESS;
+  if (blockNumber > 0) {
+    newEvent.block.number = BigInt.fromI32(blockNumber);
+  }
 
   const rewardsTupleArray: Array<ethereum.Tuple> = rewards.map<ethereum.Tuple>(
     (reward) => {

--- a/subgraphs/bridgeworld/tests/helpers/legion.ts
+++ b/subgraphs/bridgeworld/tests/helpers/legion.ts
@@ -1,6 +1,6 @@
 import { newMockEvent } from "matchstick-as/assembly";
 
-import { Address, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
 import {
   LEGACY_LEGION_GENESIS_ADDRESS,
@@ -56,9 +56,13 @@ export const createLegionCraftLevelUpEvent = (
 
 export const createLegionQuestLevelUpEvent = (
   tokenId: i32,
-  level: i32
+  level: i32,
+  blockNumber: i32 = 0
 ): LegionQuestLevelUp => {
   const newEvent = changetype<LegionQuestLevelUp>(newMockEvent());
+  if (blockNumber > 0) {
+    newEvent.block.number = BigInt.fromI32(blockNumber);
+  }
   newEvent.address = Address.fromString(LEGION_METADATA_STORE_ADDRESS);
   newEvent.parameters = [
     new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),

--- a/subgraphs/bridgeworld/tests/helpers/questing.ts
+++ b/subgraphs/bridgeworld/tests/helpers/questing.ts
@@ -1,10 +1,11 @@
 import { newMockEvent } from "matchstick-as/assembly";
 
-import { Address, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
 import { QUESTING_ADDRESS } from ".";
 import * as questingLegacy from "../../generated/Questing Legacy/Questing";
 import {
+  QPGained,
   QuestFinished,
   QuestRevealed,
   QuestStarted,
@@ -68,10 +69,14 @@ export const createQuestRevealedEvent = (
   starlights: i32 = 0,
   crystals: i32 = 0,
   locks: i32 = 0,
-  treasureId: i32 = 0
+  treasureId: i32 = 0,
+  blockNumber: i32 = 0
 ): QuestRevealed => {
   const newEvent = changetype<QuestRevealed>(newMockEvent());
   newEvent.address = Address.fromString(QUESTING_ADDRESS);
+  if (blockNumber > 0) {
+    newEvent.block.number = BigInt.fromI32(blockNumber);
+  }
   newEvent.parameters = [
     new ethereum.EventParam(
       "_owner",
@@ -109,4 +114,19 @@ export const createQuestFinishedEvent = (
   ];
 
   return newEvent;
+};
+
+export const createQuestXpGainedEvent = (
+  tokenId: i32,
+  questLevel: i32,
+  qpFinal: i32
+): QPGained => {
+  const event = changetype<QPGained>(newMockEvent());
+  event.parameters = [
+    new ethereum.EventParam("_tokenId", ethereum.Value.fromI32(tokenId)),
+    new ethereum.EventParam("_questLevel", ethereum.Value.fromI32(questLevel)),
+    new ethereum.EventParam("_qpFinal", ethereum.Value.fromI32(qpFinal)),
+  ];
+
+  return event;
 };


### PR DESCRIPTION
- Adds new handlers for Questing XP gained events
- Adds checks to skip old Questing XP calculations after upgrade block number

Deployed to testnet: https://thegraph.com/hosted-service/subgraph/treasureproject/bridgeworld-dev