### PR TITLE
add quest and craft counts to legion metadata

### DIFF
--- a/subgraphs/bridgeworld/schema.graphql
+++ b/subgraphs/bridgeworld/schema.graphql
@@ -97,6 +97,12 @@ type LegionInfo implements Metadata @entity {
   "Crafting XP"
   craftingXp: Int!
 
+  "Number of mini crafts completed by this Legion"
+  miniCraftsCompleted: Int!
+
+  "Number of major crafts completed by this Legion"
+  majorCraftsCompleted: Int!
+
   "Rank value when deposited in Harvester"
   harvestersRank: BigInt!
 
@@ -108,6 +114,12 @@ type LegionInfo implements Metadata @entity {
 
   "Questing XP"
   questingXp: Int!
+
+  "Number of full quests completed by this Legion"
+  questsCompleted: Int!
+
+  "Distance travelled by Legion on its quests"
+  questsDistanceTravelled: Int!
 
   "Rarity (Common, Rare, etc.)"
   rarity: String!

--- a/subgraphs/bridgeworld/src/helpers/constants.ts
+++ b/subgraphs/bridgeworld/src/helpers/constants.ts
@@ -11,6 +11,8 @@ export const TREASURE_FRAGMENT_IPFS =
   "ipfs://QmUv5UT7X9qahf8bqcqZjX7TKqrJeMyRX3kxjVowz2WkRm";
 export const SUMMONING_SUCCESS_SENSITIVITY: f32 = 1;
 
+export const QUEST_DISTANCE_TRAVELLED_PER_PART = 10;
+
 const DAY = 86_400;
 const ONE_WEEK = DAY * 7;
 const TWO_WEEKS = ONE_WEEK * 2;

--- a/subgraphs/bridgeworld/src/mappings/crafting.ts
+++ b/subgraphs/bridgeworld/src/mappings/crafting.ts
@@ -158,12 +158,19 @@ export function handleCraftingRevealed(event: CraftingRevealed): void {
 export function handleCraftingFinished(event: CraftingFinished): void {
   let id = getAddressId(event.address, event.params._tokenId);
 
-  let craft = Craft.load(id);
-
-  if (!craft) {
+  const craft = Craft.load(id);
+  const outcome = Outcome.load(id);
+  if (!craft || !outcome) {
     log.error("[craft-finished] Unknown craft: {}", [id]);
-
     return;
+  }
+
+  if (outcome.success) {
+    const metadata = LegionInfo.load(`${craft.token}-metadata`);
+    if (metadata) {
+      metadata.majorCraftsCompleted += 1;
+      metadata.save();
+    }
   }
 
   craft.id = `${craft.id}-${craft.random}`;

--- a/subgraphs/bridgeworld/src/mappings/crafting.ts
+++ b/subgraphs/bridgeworld/src/mappings/crafting.ts
@@ -159,9 +159,14 @@ export function handleCraftingFinished(event: CraftingFinished): void {
   let id = getAddressId(event.address, event.params._tokenId);
 
   const craft = Craft.load(id);
-  const outcome = Outcome.load(id);
-  if (!craft || !outcome) {
+  if (!craft) {
     log.error("[craft-finished] Unknown craft: {}", [id]);
+    return;
+  }
+
+  const outcome = Outcome.load(`${id}-${craft.random}`);
+  if (!outcome) {
+    log.error("[craft-finished] Unknown craft outcome: {}", [id]);
     return;
   }
 

--- a/subgraphs/bridgeworld/src/mappings/mini-crafting.ts
+++ b/subgraphs/bridgeworld/src/mappings/mini-crafting.ts
@@ -1,3 +1,5 @@
+import { log } from "@graphprotocol/graph-ts";
+
 import { LEGION_ADDRESS, TREASURE_ADDRESS } from "@treasure/constants";
 
 import { CraftingFinished } from "../../generated/Mini Crafting/MiniCrafting";
@@ -25,15 +27,20 @@ export function handleCraftingFinished(event: CraftingFinished): void {
   outcome.success = true;
   outcome.save();
 
-  // Increase craft XP
-  if (xpGained > 0) {
-    const metadata = LegionInfo.load(`${miniCraft.token}-metadata`);
-    if (metadata && metadata.crafting != 6) {
-      metadata.craftingXp += xpGained;
-      metadata.save();
-    }
-  }
-
   miniCraft.outcome = outcome.id;
   miniCraft.save();
+
+  const metadata = LegionInfo.load(`${miniCraft.token}-metadata`);
+  if (!metadata) {
+    log.error("Legion metadata not found: {}", [miniCraft.token]);
+    return;
+  }
+
+  // Increase craft XP
+  if (xpGained > 0 && metadata.crafting != 6) {
+    metadata.craftingXp += xpGained;
+  }
+
+  metadata.miniCraftsCompleted += 1;
+  metadata.save();
 }

--- a/subgraphs/bridgeworld/src/mappings/questing.ts
+++ b/subgraphs/bridgeworld/src/mappings/questing.ts
@@ -136,8 +136,10 @@ export function handleQuestFinished(event: QuestFinished): void {
   if (metadata) {
     metadata.questsCompleted += 1;
     metadata.questsDistanceTravelled +=
-      difficulty * QUEST_DISTANCE_TRAVELLED_PER_PART;
+      (difficulty + 1) * QUEST_DISTANCE_TRAVELLED_PER_PART;
     metadata.save();
+  } else {
+    log.warning("Legion metadata not found: {}", [quest.token]);
   }
 
   quest.id = `${quest.id}-${quest.random}`;

--- a/subgraphs/bridgeworld/src/mappings/questing.ts
+++ b/subgraphs/bridgeworld/src/mappings/questing.ts
@@ -10,7 +10,12 @@ import {
   QuestStarted,
 } from "../../generated/Questing/Questing";
 import { LegionInfo, Quest, Random, Reward } from "../../generated/schema";
-import { DIFFICULTY, getAddressId, getXpPerLevel } from "../helpers";
+import {
+  DIFFICULTY,
+  QUEST_DISTANCE_TRAVELLED_PER_PART,
+  getAddressId,
+  getXpPerLevel,
+} from "../helpers";
 import { isQuestingXpGainedEnabled } from "../helpers/config";
 import { getLegionMetadata } from "../helpers/legion";
 
@@ -124,6 +129,15 @@ export function handleQuestFinished(event: QuestFinished): void {
     log.error("[finished] Unknown quest: {}", [id]);
 
     return;
+  }
+
+  const difficulty = DIFFICULTY.indexOf(quest.difficulty);
+  const metadata = LegionInfo.load(`${quest.token}-metadata`);
+  if (metadata) {
+    metadata.questsCompleted += 1;
+    metadata.questsDistanceTravelled +=
+      difficulty * QUEST_DISTANCE_TRAVELLED_PER_PART;
+    metadata.save();
   }
 
   quest.id = `${quest.id}-${quest.random}`;

--- a/subgraphs/bridgeworld/tests/advanced-questing.test.ts
+++ b/subgraphs/bridgeworld/tests/advanced-questing.test.ts
@@ -154,17 +154,17 @@ test("Part increase as quest continues", () => {
   handleAdvancedQuestStarted(
     createAdvancedQuestStartedEvent(USER_ADDRESS, legionId)
   );
-  assert.fieldEquals("AdvancedQuest", questId, "part", "0");
-
-  handleAdvancedQuestContinued(
-    createAdvancedQuestContinuedEvent(USER_ADDRESS, legionId, 1, 1)
-  );
   assert.fieldEquals("AdvancedQuest", questId, "part", "1");
 
   handleAdvancedQuestContinued(
     createAdvancedQuestContinuedEvent(USER_ADDRESS, legionId, 1, 2)
   );
   assert.fieldEquals("AdvancedQuest", questId, "part", "2");
+
+  handleAdvancedQuestContinued(
+    createAdvancedQuestContinuedEvent(USER_ADDRESS, legionId, 1, 3)
+  );
+  assert.fieldEquals("AdvancedQuest", questId, "part", "3");
 });
 
 test("XP increases based on level when quest ends", () => {
@@ -177,11 +177,23 @@ test("XP increases based on level when quest ends", () => {
   for (let level = 1; level < 6; level++) {
     assert.fieldEquals("LegionInfo", mdId, "questing", `${level}`);
     assert.fieldEquals("LegionInfo", mdId, "questingXp", "0");
-
     for (let questIndex = 1; questIndex <= 3; questIndex++) {
       simulateAdvancedQuest(USER_ADDRESS, legionId);
       const xp = getXpPerLevel(level) * questIndex;
+      const questsCompleted = level * 3 - (3 - questIndex);
       assert.fieldEquals("LegionInfo", mdId, "questingXp", `${xp}`);
+      assert.fieldEquals(
+        "LegionInfo",
+        mdId,
+        "questsCompleted",
+        questsCompleted.toString()
+      );
+      assert.fieldEquals(
+        "LegionInfo",
+        mdId,
+        "questsDistanceTravelled",
+        (questsCompleted * 10).toString()
+      );
     }
 
     handleLegionQuestLevelUp(
@@ -190,23 +202,6 @@ test("XP increases based on level when quest ends", () => {
   }
 
   assert.fieldEquals("LegionInfo", mdId, "questing", "6");
-});
-
-test("XP doesn't increase at level 6", () => {
-  const legionId = 1;
-  const legionStoreId = advancedQuestingSetup(legionId);
-  const mdId = `${legionStoreId}-metadata`;
-
-  mockEndTimeForLegion(legionId, new Date(0).getTime(), 0);
-
-  handleLegionQuestLevelUp(createLegionQuestLevelUpEvent(legionId, 6));
-  assert.fieldEquals("LegionInfo", mdId, "questing", "6");
-
-  simulateAdvancedQuest(USER_ADDRESS, legionId);
-  assert.fieldEquals("LegionInfo", mdId, "questingXp", "0");
-
-  simulateAdvancedQuest(USER_ADDRESS, legionId);
-  assert.fieldEquals("LegionInfo", mdId, "questingXp", "0");
 });
 
 test("XP doesn't increase at level 6", () => {

--- a/subgraphs/bridgeworld/tests/crafting.test.ts
+++ b/subgraphs/bridgeworld/tests/crafting.test.ts
@@ -64,6 +64,12 @@ test("crafting increases xp when completed successfully", () => {
 
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "crafting", "1");
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "craftingXp", "0");
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "majorCraftsCompleted",
+    "0"
+  );
 
   let craftsToLevelUp = 14;
 
@@ -119,6 +125,13 @@ test("crafting increases xp when completed successfully", () => {
 
     handleCraftingFinished(craftFinishedEvent);
   }
+
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "majorCraftsCompleted",
+    craftsToLevelUp.toString()
+  );
 
   craftsToLevelUp = 16;
 
@@ -377,6 +390,12 @@ test("crafting xp does not increase on failure", () => {
 
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "crafting", "1");
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "craftingXp", "0");
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "majorCraftsCompleted",
+    "0"
+  );
 
   // Perform a craft
   const randomRequestEvent = createRandomRequestEvent(1, 2);
@@ -404,6 +423,12 @@ test("crafting xp does not increase on failure", () => {
   handleCraftingRevealed(craftRevealedEvent);
 
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "craftingXp", "0");
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "majorCraftsCompleted",
+    "0"
+  );
 
   const craftFinishedEvent = createCraftingFinishedEvent(USER_ADDRESS, 1);
 

--- a/subgraphs/bridgeworld/tests/helpers/advanced-questing.ts
+++ b/subgraphs/bridgeworld/tests/helpers/advanced-questing.ts
@@ -102,7 +102,7 @@ export function createAdvancedQuestStartedEvent(
   legionId: i32 = 1,
   requestId: i32 = 1,
   zoneName: string = "A",
-  toPart: i8 = 0,
+  toPart: i8 = 1,
   treasureIds: i32[] = [1, 2, 3],
   treasureAmounts: i32[] = [1, 1, 1]
 ): AdvancedQuestStarted {

--- a/subgraphs/bridgeworld/tests/mini-crafting.test.ts
+++ b/subgraphs/bridgeworld/tests/mini-crafting.test.ts
@@ -21,6 +21,12 @@ import { createMiniCraftingFinishedEvent } from "./helpers/mini-crafting";
 test("mini crafting outcome is stored", () => {
   clearStore();
 
+  // Mint & create Legion
+  handleTransfer(
+    createLegionTransferEvent(Address.zero().toHexString(), USER_ADDRESS, 1)
+  );
+  handleLegionCreated(createLegionCreatedEvent(USER_ADDRESS, 1, 0, 6, 2));
+
   // Finish mini craft
   handleCraftingFinished(
     createMiniCraftingFinishedEvent("1653084615", USER_ADDRESS, 1, 4, 114)
@@ -65,10 +71,7 @@ test("mini crafting increases xp when emitted", () => {
   );
 
   // Assert Legion crafting XP was increased
-  assert.fieldEquals(
-    LEGION_INFO_ENTITY_TYPE,
-    `${LEGION_ADDRESS.toHexString()}-0x1-metadata`,
-    "craftingXp",
-    "20"
-  );
+  const id = `${LEGION_ADDRESS.toHexString()}-0x1-metadata`;
+  assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, id, "craftingXp", "20");
+  assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, id, "miniCraftsCompleted", "1");
 });

--- a/subgraphs/bridgeworld/tests/questing.test.ts
+++ b/subgraphs/bridgeworld/tests/questing.test.ts
@@ -65,6 +65,13 @@ test("questing increases xp when completed", () => {
 
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questing", "1");
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questingXp", "0");
+  assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questsCompleted", "0");
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "questsDistanceTravelled",
+    "0"
+  );
 
   let questsToLevelUp = 10;
 
@@ -111,6 +118,19 @@ test("questing increases xp when completed", () => {
 
     handleQuestFinished(questFinishedEvent);
   }
+
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "questsCompleted",
+    questsToLevelUp.toString()
+  );
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "questsDistanceTravelled",
+    (questsToLevelUp * 10).toString()
+  );
 
   questsToLevelUp = 20;
 
@@ -315,6 +335,13 @@ test("questing xp does not increase at max level (6)", () => {
 
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questing", "1");
   assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questingXp", "0");
+  assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questsCompleted", "0");
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "questsDistanceTravelled",
+    "0"
+  );
 
   // Short cut to max level
   const questLevelUp = createLegionQuestLevelUpEvent(1, 6);
@@ -351,6 +378,14 @@ test("questing xp does not increase at max level (6)", () => {
   const questFinishedEvent = createQuestFinishedEvent(USER_ADDRESS, 1);
 
   handleQuestFinished(questFinishedEvent);
+
+  assert.fieldEquals(LEGION_INFO_ENTITY_TYPE, metadata, "questsCompleted", "1");
+  assert.fieldEquals(
+    LEGION_INFO_ENTITY_TYPE,
+    metadata,
+    "questsDistanceTravelled",
+    "10"
+  );
 });
 
 test("legacy questing xp does not increase after upgrade block", () => {


### PR DESCRIPTION
Adds new fields to the `LegionInfo` entity for tracking quest and craft counts plus a new "distance travelled" concept