### PR TITLE
refetch collection metadata when base uri changes

### DIFF
--- a/subgraphs/smolverse/src/mappings/smol-brains.ts
+++ b/subgraphs/smolverse/src/mappings/smol-brains.ts
@@ -1,11 +1,40 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
 import {
+  BaseURIChanged,
   ERC721WithBaseUri,
   Transfer,
 } from "../../generated/Smol Brains/ERC721WithBaseUri";
-import { SMOL_BRAINS_BASE_URI } from "../helpers/constants";
+import {
+  MISSING_METADATA_UPDATE_INTERVAL,
+  SMOL_BRAINS_BASE_URI,
+} from "../helpers/constants";
 import { getAttributeId } from "../helpers/ids";
+import { checkMissingMetadata } from "../helpers/metadata";
 import { getOrCreateAttribute, getOrCreateCollection } from "../helpers/models";
 import { handleTransfer as commonHandleTransfer } from "./common";
+
+export function handleBaseUriChanged(event: BaseURIChanged): void {
+  const collection = getOrCreateCollection(event.address, false);
+
+  // Add current tokenIds to missing metadata to be reprocessed
+  collection._missingMetadataTokens = collection._missingMetadataTokens.concat(
+    collection._tokenIds
+  );
+
+  // Set last timestamp in the past so the reprocess of metadata starts
+  collection._missingMetadataLastUpdated =
+    collection._missingMetadataLastUpdated.minus(
+      BigInt.fromI32(MISSING_METADATA_UPDATE_INTERVAL)
+    );
+
+  // Save new base URI
+  collection.baseUri = event.params.to;
+  collection.save();
+
+  // Start metadata re-fetching
+  checkMissingMetadata(collection, event.block.timestamp);
+}
 
 export function handleTransfer(event: Transfer): void {
   const address = event.address;
@@ -15,9 +44,10 @@ export function handleTransfer(event: Transfer): void {
   if (!collection.baseUri) {
     const contract = ERC721WithBaseUri.bind(address);
     const baseUriCall = contract.try_baseURI();
-    collection.baseUri = baseUriCall.reverted
-      ? SMOL_BRAINS_BASE_URI
-      : baseUriCall.value;
+    collection.baseUri =
+      baseUriCall.reverted || baseUriCall.value.length === 0
+        ? SMOL_BRAINS_BASE_URI
+        : baseUriCall.value;
     collection.save();
   }
 

--- a/subgraphs/smolverse/template.yaml
+++ b/subgraphs/smolverse/template.yaml
@@ -129,6 +129,8 @@ dataSources:
         - name: ERC721WithBaseUri
           file: ./abis/ERC721WithBaseUri.json
       eventHandlers:
+        - event: BaseURIChanged(string,string)
+          handler: handleBaseUriChanged
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
       file: ./src/mappings/smol-brains.ts


### PR DESCRIPTION
- Defaults to hard-coded base URI if the contract call returns an empty string
- Queues up all Smol Brains tokens for metadata refetching when base URI changes