### PR TITLE
Added comment to Legion variant with no background

### DIFF
--- a/subgraphs/bridgeworld/src/helpers/legion.ts
+++ b/subgraphs/bridgeworld/src/helpers/legion.ts
@@ -364,6 +364,7 @@ const convertTokenIdToVariant = (
 
   let variant = "";
   if (!hasBackground) {
+    // Legion images without a background always have the 1 variant
     variant += "1";
   } else if (mappedDigit1) {
     variant += mappedDigit1;


### PR DESCRIPTION
I accidentally created the branch and didn't switch to it so the main changes were pushed straight to `master`.
The action was cancelled so it didn't override the current subgraph syncing.
The commit can be viewed here for review: https://github.com/TreasureProject/treasure-subgraphs/commit/3b9497e9be1f760bb82d488381379632208d1349